### PR TITLE
Check Context for Initial Values

### DIFF
--- a/zcl_logger.abap
+++ b/zcl_logger.abap
@@ -351,7 +351,7 @@ METHOD new.
     r_log->auto_save = abap_true.
   ENDIF.
 
-  IF context IS SUPPLIED.
+  IF context IS SUPPLIED AND context IS NOT INITIAL.
     r_log->header-context-tabname =
       cl_abap_typedescr=>describe_by_data( context )->get_ddic_header( )-tabname.
     ASSIGN context TO <context_val> CASTING.


### PR DESCRIPTION
Check if context is not initial since an empty parameter causes an exception.