### PR TITLE
Moved public methods to interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ do you wish the ABAP example above looked like?  How about this:
 ## Usage
 
 ```abap
-DATA: log TYPE REF TO zcl_logger.
+DATA: log TYPE REF TO zif_logger.
 
-log = zcl_logger=>new( object = 'ZINTERFACES'
-                       subobject = 'ACCOUNTING'
-                       desc = 'Stuff imported from legacy systems' ).
+log = zcl_logger_factory=>create_log( object = 'ZINTERFACES'
+                                      subobject = 'ACCOUNTING'
+                                      desc = 'Stuff imported from legacy systems' ).
 
 log->e( 'You see, what had happened was...' ).
 ```
@@ -77,13 +77,13 @@ log->e( 'You see, what had happened was...' ).
 Method calls can be chained, too. 
 
 ```abap
-zcl_logger=>new( object = 'foo' )->e( 'Bad things happened: See details' )->e( error ).
+zcl_logger_factory=>create_log( object = 'foo' )->e( 'Bad things happened: See details' )->e( error ).
 ```
 
 ## Logging Different Types
 
 Making use of SAP's run-time type services, we can pass almost anything we
-might want to log to an instance of ZCL_LOGGER, and it will do the heavy lifting.
+might want to log to an instance of ZIF_LOGGER, and it will do the heavy lifting.
 
 Log a string:
 

--- a/zcl_logger.clas.abap
+++ b/zcl_logger.clas.abap
@@ -16,6 +16,20 @@ class zcl_logger definition
     data handle type balloghndl read-only .
     data db_number type balognr read-only .
 
+    interfaces zif_logger.
+    aliases: add for zif_logger~add,
+             a for zif_logger~a,
+             e for zif_logger~e,
+             w for zif_logger~w,
+             i for zif_logger~i,
+             s for zif_logger~s,
+             save for zif_logger~save,
+             get_autosave for zif_logger~get_autosave,
+             set_autosave for zif_logger~set_autosave,
+             export_to_table for zif_logger~export_to_table,
+             fullscreen for zif_logger~fullscreen,
+             popup for zif_logger~popup.
+
     class-methods new
       importing
         !object         type csequence optional
@@ -35,85 +49,7 @@ class zcl_logger definition
         !auto_save                type abap_bool optional
       returning
         value(r_log)              type ref to zcl_logger .
-    methods add
-      importing
-        !obj_to_log    type any optional
-        !context       type simple optional
-        !callback_form type csequence optional
-        !callback_prog type csequence optional
-        !callback_fm   type csequence optional
-        !type          type symsgty optional
-        !importance    type balprobcl optional
-          preferred parameter obj_to_log
-      returning
-        value(self)    type ref to zcl_logger .
-    methods a
-      importing
-        !obj_to_log    type any optional
-        !context       type simple optional
-        !callback_form type csequence optional
-        !callback_prog type csequence optional
-        !callback_fm   type csequence optional
-        !importance    type balprobcl optional
-          preferred parameter obj_to_log
-      returning
-        value(self)    type ref to zcl_logger .
-    methods e
-      importing
-        !obj_to_log    type any optional
-        !context       type simple optional
-        !callback_form type csequence optional
-        !callback_prog type csequence optional
-        !callback_fm   type csequence optional
-        !importance    type balprobcl optional
-          preferred parameter obj_to_log
-      returning
-        value(self)    type ref to zcl_logger .
-    methods w
-      importing
-        !obj_to_log    type any optional
-        !context       type simple optional
-        !callback_form type csequence optional
-        !callback_prog type csequence optional
-        !callback_fm   type csequence optional
-        !importance    type balprobcl optional
-          preferred parameter obj_to_log
-      returning
-        value(self)    type ref to zcl_logger .
-    methods i
-      importing
-        !obj_to_log    type any optional
-        !context       type simple optional
-        !callback_form type csequence optional
-        !callback_prog type csequence optional
-        !callback_fm   type csequence optional
-        !importance    type balprobcl optional
-          preferred parameter obj_to_log
-      returning
-        value(self)    type ref to zcl_logger .
-    methods s
-      importing
-        !obj_to_log    type any optional
-        !context       type simple optional
-        !callback_form type csequence optional
-        !callback_prog type csequence optional
-        !callback_fm   type csequence optional
-        !importance    type balprobcl optional
-          preferred parameter obj_to_log
-      returning
-        value(self)    type ref to zcl_logger .
-    methods popup .
-    methods fullscreen .
-    methods export_to_table
-      returning
-        value(rt_bapiret) type bapirettab .
-    methods get_autosave
-      returning
-        value(auto_save) type abap_bool .
-    methods set_autosave
-      importing
-        !auto_save type abap_bool .
-    methods save .
+
   protected section.
 *"* protected components of class ZCL_LOGGER
 *"* do not include other source files here!!!
@@ -127,7 +63,7 @@ class zcl_logger definition
     types: begin of hrpad_message_alike,
              cause(32)    type c,              "original: hrpad_message_cause
              detail_level type ballevel.
-        include type symsg .
+            include type symsg .
     types: field_list type standard table of hrpad_message_field_list_alike
            with non-unique key scrrprfd.
     types: end of hrpad_message_alike.
@@ -137,11 +73,11 @@ class zcl_logger definition
     data auto_save type abap_bool .
     data sec_connection type abap_bool .
     data sec_connect_commit type abap_bool .
-ENDCLASS.
+endclass.
 
 
 
-CLASS ZCL_LOGGER IMPLEMENTATION.
+class zcl_logger implementation.
 
 
   method a.
@@ -619,4 +555,4 @@ CLASS ZCL_LOGGER IMPLEMENTATION.
       type          = 'W'
       importance    = importance ).
   endmethod.
-ENDCLASS.
+endclass.

--- a/zcl_logger.clas.abap
+++ b/zcl_logger.clas.abap
@@ -5,16 +5,13 @@
 *----------------------------------------------------------------------*
 class zcl_logger definition
   public
-  create private .
+  create private
+  global friends zcl_logger_factory .
 
   public section.
-    type-pools abap .
-
 *"* public components of class ZCL_LOGGER
 *"* do not include other source files here!!!
-    data header type bal_s_log read-only .
-    data handle type balloghndl read-only .
-    data db_number type balognr read-only .
+    type-pools abap .
 
     interfaces zif_logger.
     aliases: add for zif_logger~add,
@@ -28,8 +25,12 @@ class zcl_logger definition
              set_autosave for zif_logger~set_autosave,
              export_to_table for zif_logger~export_to_table,
              fullscreen for zif_logger~fullscreen,
-             popup for zif_logger~popup.
+             popup for zif_logger~popup,
+             handle for zif_logger~handle,
+             db_number for zif_logger~db_number,
+             header for zif_logger~header.
 
+    " backwards compatibility only -> use zcl_logger_factory instead
     class-methods new
       importing
         !object         type csequence optional
@@ -39,7 +40,9 @@ class zcl_logger definition
         !auto_save      type abap_bool optional
         !second_db_conn type abap_bool default abap_true
       returning
-        value(r_log)    type ref to zcl_logger .
+        value(r_log)    type ref to zif_logger .
+
+    " backwards compatibility only -> use zcl_logger_factory instead
     class-methods open
       importing
         !object                   type csequence
@@ -48,7 +51,7 @@ class zcl_logger definition
         !create_if_does_not_exist type abap_bool default abap_false
         !auto_save                type abap_bool optional
       returning
-        value(r_log)              type ref to zcl_logger .
+        value(r_log)              type ref to zif_logger .
 
   protected section.
 *"* protected components of class ZCL_LOGGER
@@ -338,136 +341,46 @@ class zcl_logger implementation.
 
   method new.
 
-*-- Added AUTO_SAVE as a parameter.  There are times when
-*-- you do not want to save the log unless certain kinds
-*-- of messages are put in the log.  By allowing the explicit
-*-- setting of the AUTO_SAVE value, this can be done
-*-- The SAVE method must be called at the end processing
-*-- to save all of the log data
-
-    field-symbols <context_val> type c.
-
-    create object r_log.
-    r_log->header-object = object.
-    r_log->header-subobject = subobject.
-    r_log->header-extnumber = desc.
-
-*-- If AUTO_SAVE is not passed in, then use the old logic
-*-- This is to ensure backwards compatiblilty
     if auto_save is supplied.
-      r_log->auto_save = auto_save.
+      r_log = zcl_logger_factory=>create_log(
+        !object = object
+        !subobject = subobject
+        !desc = desc
+        !context = context
+        !auto_save = auto_save
+        !second_db_conn = second_db_conn
+      ).
     else.
-      if object is not initial and subobject is not initial.
-        r_log->auto_save = abap_true.
-      endif.
+      r_log = zcl_logger_factory=>create_log(
+        !object = object
+        !subobject = subobject
+        !desc = desc
+        !context = context
+        !second_db_conn = second_db_conn
+      ).
     endif.
-
-* Use secondary database connection to write data to database even if
-* main program does a rollback (e. g. during a dump).
-    if second_db_conn = abap_true.
-      r_log->sec_connection = abap_true.
-      r_log->sec_connect_commit = abap_true.
-    endif.
-
-    if context is supplied and context is not initial.
-      r_log->header-context-tabname =
-        cl_abap_typedescr=>describe_by_data( context )->get_ddic_header( )-tabname.
-      assign context to <context_val> casting.
-      r_log->header-context-value = <context_val>.
-    endif.
-
-    call function 'BAL_LOG_CREATE'
-      exporting
-        i_s_log      = r_log->header
-      importing
-        e_log_handle = r_log->handle.
-
-* BAL_LOG_CREATE will fill in some additional header data.
-* This FM updates our instance attribute to reflect that.
-    call function 'BAL_LOG_HDR_READ'
-      exporting
-        i_log_handle = r_log->handle
-      importing
-        e_s_log      = r_log->header.
 
   endmethod.
 
 
   method open.
 
-*-- Added AUTO_SAVE as a parameter.  There are times when
-*-- you do not want to save the log unless certain kinds
-*-- of messages are put in the log.  By allowing the explicit
-*-- setting of the AUTO_SAVE value, this can be done
-*-- The SAVE method must be called at the end processing
-*-- to save all of the log data
-
-    data: filter             type bal_s_lfil,
-          desc_filter        type bal_s_extn,
-          obj_filter         type bal_s_obj,
-          subobj_filter      type bal_s_sub,
-
-          found_headers      type balhdr_t,
-          most_recent_header type balhdr,
-          handles_loaded     type bal_t_logh.
-
-    desc_filter-option = subobj_filter-option = obj_filter-option = 'EQ'.
-    desc_filter-sign = subobj_filter-sign = obj_filter-sign = 'I'.
-
-    obj_filter-low = object.
-    append obj_filter to filter-object.
-    subobj_filter-low = subobject.
-    append subobj_filter to filter-subobject.
-    if desc is supplied.
-      desc_filter-low = desc.
-      append desc_filter to filter-extnumber.
-    endif.
-
-    call function 'BAL_DB_SEARCH'
-      exporting
-        i_s_log_filter = filter
-      importing
-        e_t_log_header = found_headers
-      exceptions
-        log_not_found  = 1.
-
-    if sy-subrc = 1.
-      if create_if_does_not_exist = abap_true.
-        r_log = zcl_logger=>new( object    = object
-                                 subobject = subobject
-                                 desc      = desc ).
-      endif.
-      return.
-    endif.
-
-* Delete all but the last row.  Keep the found_headers table this way
-* so we can pass it to BAL_DB_LOAD.
-    if lines( found_headers ) > 1.
-      delete found_headers to ( lines( found_headers ) - 1 ).
-    endif.
-    read table found_headers index 1 into most_recent_header.
-
-    create object r_log.
-*-- If AUTO_SAVE is not passed in, then use the old logic
-*-- This is to ensure backwards compatiblilty
-    if auto_save is not supplied.
-      r_log->auto_save = abap_true.
+    if auto_save is supplied.
+      r_log = zcl_logger_factory=>open_log(
+        !object = object
+        !subobject = subobject
+        !desc = desc
+        !create_if_does_not_exist = create_if_does_not_exist
+        !auto_save = auto_save
+      ).
     else.
-      r_log->auto_save = auto_save.
+      r_log = zcl_logger_factory=>open_log(
+        !object = object
+        !subobject = subobject
+        !desc = desc
+        !create_if_does_not_exist = create_if_does_not_exist
+      ).
     endif.
-
-    r_log->db_number = most_recent_header-lognumber.
-    r_log->handle = most_recent_header-log_handle.
-
-    call function 'BAL_DB_LOAD'
-      exporting
-        i_t_log_header = found_headers.
-
-    call function 'BAL_LOG_HDR_READ'
-      exporting
-        i_log_handle = r_log->handle
-      importing
-        e_s_log      = r_log->header.
 
   endmethod.
 

--- a/zcl_logger.clas.testclasses.abap
+++ b/zcl_logger.clas.testclasses.abap
@@ -24,9 +24,9 @@ class lcl_test definition for testing
   private section.
 
     data:
-      anon_log     type ref to zcl_logger,
-      named_log    type ref to zcl_logger,
-      reopened_log type ref to zcl_logger.
+      anon_log     type ref to zif_logger,
+      named_log    type ref to zif_logger,
+      reopened_log type ref to zif_logger.
 
     class-methods:
       class_setup.
@@ -123,7 +123,7 @@ class lcl_test implementation.
   endmethod.
 
   method can_open_or_create.
-    data: created_log type ref to zcl_logger,
+    data: created_log type ref to zif_logger,
           handles     type bal_t_logh.
     call function 'BAL_GLB_MEMORY_REFRESH'. "Close Logs
     reopened_log = zcl_logger=>open( object = 'ABAPUNIT'
@@ -147,7 +147,7 @@ class lcl_test implementation.
 
   method can_add_log_context.
 
-    data: log                 type ref to zcl_logger,
+    data: log                 type ref to zif_logger,
           random_country_data type t005t,
           act_header          type bal_s_log.
 

--- a/zcl_logger.clas.xml
+++ b/zcl_logger.clas.xml
@@ -13,6 +13,325 @@
     <UNICODE>X</UNICODE>
     <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
+   <TPOOL>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+    <item/>
+   </TPOOL>
+   <LINES>
+    <TLINE>
+     <TDFORMAT>U1</TDFORMAT>
+     <TDLINE>&amp;FUNCTIONALITY&amp;</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>AS</TDFORMAT>
+     <TDLINE>The class ZCL_LOGGER is designed to make logging in ABAP more like in</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDLINE>other languages.  To create a log and add messages in Android Java,</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDLINE>Ruby, and Javascript, at most two lines of code are required: one to</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDLINE>create the log and one to add the message.  In addition, different types</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDLINE>of objects can be logged by passing them to the same method.  ZCL_LOGGER</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDLINE>also has these strengths.</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>AS</TDFORMAT>
+     <TDLINE>An instance of this class can be passed a number of objects by different</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDLINE>methods.  Method ADD accepts a string, bapiret2, bdcmsgcoll, exception</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDLINE>object, or a table of any of those data types.  Methods A, E, W, I and S</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDLINE>accept exactly the same but they add the type of message corresponding</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDLINE>to their names.</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>U1</TDFORMAT>
+     <TDLINE>&amp;RELATIONS&amp;</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>AS</TDFORMAT>
+     <TDLINE>ZCL_LOGGER makes a bunch of calls to function group</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>=</TDFORMAT>
+     <TDLINE> &lt;DS:RE.SAPLSBAL&gt;SBAL&lt;/&gt;.</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>U1</TDFORMAT>
+     <TDLINE>&amp;EXAMPLE&amp;</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>U3</TDFORMAT>
+     <TDLINE>Creating a Log in SLG1</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>PE</TDFORMAT>
+     <TDLINE>DATA: log TYPE REF TO zcl_logger.</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+     <TDLINE>* If you create a log without any parameters, it will only be in memory</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+     <TDLINE>log = zcl_logger=&gt;new( ).</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+     <TDLINE>* If you supply an object and subobject, the log will be created on the</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+     <TDLINE>* database the first time a message is stored, so you can view it later</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+     <TDLINE>* in SLG1.</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+     <TDLINE>log = zcl_logger=&gt;new( object = &apos;WF&apos;</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+     <TDLINE>                       subobject = &apos;NOTIFICATIONS&apos;</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+     <TDLINE>                       desc = |Notifications on { sy-datum }| ).</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>U3</TDFORMAT>
+     <TDLINE>Logging Strings</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>PE</TDFORMAT>
+     <TDLINE>DATA: log TYPE REF TO zcl_logger.</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+     <TDLINE>log = zcl_logger=&gt;new( ).</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+     <TDLINE>log-&gt;s( &apos;This is a success message&apos; ).</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+     <TDLINE>log-&gt;w( &apos;This is a warning message&apos; ).</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>U3</TDFORMAT>
+     <TDLINE>Logging Errors</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>PE</TDFORMAT>
+     <TDLINE>DATA: log TYPE REF TO zcl_logger,</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+     <TDLINE>      l_err TYPE REF TO zcx_operation_failed.</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+     <TDLINE>log = zcl_logger=&gt;new( object = &apos;WF&apos; subobject = &apos;NOTIFICATIONS&apos; ).</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+     <TDLINE>TRY.</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+     <TDLINE>    my_class=&gt;do_some_operation( ).</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+     <TDLINE>  CATCH zcx_operation_failed INTO l_err.</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+     <TDLINE>    log-&gt;e( l_err ).</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+     <TDLINE>ENDTRY.</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>U3</TDFORMAT>
+     <TDLINE>Logging BAPI Messages</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>PE</TDFORMAT>
+     <TDLINE>DATA: rtn_msgs TYPE TABLE OF bapiret2.</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+     <TDLINE>CALL FUNCTION &apos;BAPI_ACC_DOCUMENT_POST&apos;</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+     <TDLINE>  EXPORTING</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+     <TDLINE>    parameter1 = foo</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+     <TDLINE>    parameter2 = bar</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+     <TDLINE>  TABLES</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+     <TDLINE>    return = rtn_msgs.</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+     <TDLINE>IF rtn_msgs IS NOT INITIAL.</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+     <TDLINE>  log = zcl_logger=&gt;new( object = &apos;ACCOUNTING&apos; subobject = &apos;INTERFACES&apos;</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDLINE>).</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+     <TDLINE>  log-&gt;add( rtn_msgs ).</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+     <TDLINE>ENDIF.</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>U3</TDFORMAT>
+     <TDLINE>Displaying a log</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>PE</TDFORMAT>
+     <TDLINE>log-&gt;popup( ).</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>/</TDFORMAT>
+     <TDLINE>log-&gt;fullscreen( ).</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>AS</TDFORMAT>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>U1</TDFORMAT>
+     <TDLINE>&amp;HINTS&amp;</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>AS</TDFORMAT>
+     <TDLINE>Calls to the log can be chained, like:</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>PE</TDFORMAT>
+     <TDLINE>log-&gt;e( &apos;An error occurred. See following:&apos; )-&gt;e( l_err ).</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>U1</TDFORMAT>
+     <TDLINE>&amp;FURTHER_SOURCES_OF_INF&amp;</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>AS</TDFORMAT>
+     <TDLINE>If you plan on modifying or adding to this class, see the local unit</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDLINE>tests.  You can run them and they will test the class in a number of</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDLINE>different scenarios.  You can set breakpoints before running unit tests</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDLINE>to see the behavior in action.</TDLINE>
+    </TLINE>
+   </LINES>
   </asx:values>
  </asx:abap>
 </abapGit>

--- a/zcl_logger_factory.clas.abap
+++ b/zcl_logger_factory.clas.abap
@@ -1,0 +1,178 @@
+class zcl_logger_factory definition
+  public
+  final
+  create private .
+
+  public section.
+
+    class-methods create_log
+      importing
+        !object         type csequence optional
+        !subobject      type csequence optional
+        !desc           type csequence optional
+        !context        type simple optional
+        !auto_save      type abap_bool optional
+        !second_db_conn type abap_bool default abap_true
+      returning
+        value(r_log)    type ref to zif_logger .
+
+    class-methods open_log
+      importing
+        !object                   type csequence
+        !subobject                type csequence
+        !desc                     type csequence optional
+        !create_if_does_not_exist type abap_bool default abap_false
+        !auto_save                type abap_bool optional
+      returning
+        value(r_log)              type ref to zif_logger .
+
+  protected section.
+  private section.
+endclass.
+
+
+
+class zcl_logger_factory implementation.
+
+  method create_log.
+
+*-- Added AUTO_SAVE as a parameter.  There are times when
+*-- you do not want to save the log unless certain kinds
+*-- of messages are put in the log.  By allowing the explicit
+*-- setting of the AUTO_SAVE value, this can be done
+*-- The SAVE method must be called at the end processing
+*-- to save all of the log data
+
+    data: lo_log type ref to zcl_logger.
+    field-symbols <context_val> type c.
+
+    create object lo_log.
+    lo_log->header-object = object.
+    lo_log->header-subobject = subobject.
+    lo_log->header-extnumber = desc.
+
+*-- If AUTO_SAVE is not passed in, then use the old logic
+*-- This is to ensure backwards compatiblilty
+    if auto_save is supplied.
+      lo_log->auto_save = auto_save.
+    else.
+      if object is not initial and subobject is not initial.
+        lo_log->auto_save = abap_true.
+      endif.
+    endif.
+
+* Use secondary database connection to write data to database even if
+* main program does a rollback (e. g. during a dump).
+    if second_db_conn = abap_true.
+      lo_log->sec_connection = abap_true.
+      lo_log->sec_connect_commit = abap_true.
+    endif.
+
+    if context is supplied and context is not initial.
+      lo_log->header-context-tabname =
+        cl_abap_typedescr=>describe_by_data( context )->get_ddic_header( )-tabname.
+      assign context to <context_val> casting.
+      lo_log->header-context-value = <context_val>.
+    endif.
+
+    call function 'BAL_LOG_CREATE'
+      exporting
+        i_s_log      = lo_log->header
+      importing
+        e_log_handle = lo_log->handle.
+
+* BAL_LOG_CREATE will fill in some additional header data.
+* This FM updates our instance attribute to reflect that.
+    call function 'BAL_LOG_HDR_READ'
+      exporting
+        i_log_handle = lo_log->handle
+      importing
+        e_s_log      = lo_log->header.
+
+    r_log = lo_log.
+
+  endmethod.
+
+
+  method open_log.
+
+*-- Added AUTO_SAVE as a parameter.  There are times when
+*-- you do not want to save the log unless certain kinds
+*-- of messages are put in the log.  By allowing the explicit
+*-- setting of the AUTO_SAVE value, this can be done
+*-- The SAVE method must be called at the end processing
+*-- to save all of the log data
+
+    data: filter             type bal_s_lfil,
+          desc_filter        type bal_s_extn,
+          obj_filter         type bal_s_obj,
+          subobj_filter      type bal_s_sub,
+
+          found_headers      type balhdr_t,
+          most_recent_header type balhdr,
+          handles_loaded     type bal_t_logh.
+    data: lo_log type ref to zcl_logger.
+
+    desc_filter-option = subobj_filter-option = obj_filter-option = 'EQ'.
+    desc_filter-sign = subobj_filter-sign = obj_filter-sign = 'I'.
+
+    obj_filter-low = object.
+    append obj_filter to filter-object.
+    subobj_filter-low = subobject.
+    append subobj_filter to filter-subobject.
+    if desc is supplied.
+      desc_filter-low = desc.
+      append desc_filter to filter-extnumber.
+    endif.
+
+    call function 'BAL_DB_SEARCH'
+      exporting
+        i_s_log_filter = filter
+      importing
+        e_t_log_header = found_headers
+      exceptions
+        log_not_found  = 1.
+
+    if sy-subrc = 1.
+      if create_if_does_not_exist = abap_true.
+        r_log = zcl_logger=>new( object    = object
+                                 subobject = subobject
+                                 desc      = desc ).
+      endif.
+      return.
+    endif.
+
+* Delete all but the last row.  Keep the found_headers table this way
+* so we can pass it to BAL_DB_LOAD.
+    if lines( found_headers ) > 1.
+      delete found_headers to ( lines( found_headers ) - 1 ).
+    endif.
+    read table found_headers index 1 into most_recent_header.
+
+    create object lo_log.
+*-- If AUTO_SAVE is not passed in, then use the old logic
+*-- This is to ensure backwards compatiblilty
+    if auto_save is not supplied.
+      lo_log->auto_save = abap_true.
+    else.
+      lo_log->auto_save = auto_save.
+    endif.
+
+    lo_log->db_number = most_recent_header-lognumber.
+    lo_log->handle = most_recent_header-log_handle.
+
+    call function 'BAL_DB_LOAD'
+      exporting
+        i_t_log_header = found_headers.
+
+    call function 'BAL_LOG_HDR_READ'
+      exporting
+        i_log_handle = lo_log->handle
+      importing
+        e_s_log      = lo_log->header.
+
+    r_log = lo_log.
+
+  endmethod.
+
+endclass.

--- a/zcl_logger_factory.clas.xml
+++ b/zcl_logger_factory.clas.xml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_LOGGER_FACTORY</CLSNAME>
+    <VERSION>1</VERSION>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Logger Factory</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSFINAL>X</CLSFINAL>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/zif_logger.intf.abap
+++ b/zif_logger.intf.abap
@@ -1,5 +1,8 @@
 interface zif_logger
   public .
+  data handle type balloghndl read-only .
+  data db_number type balognr read-only .
+  data header type bal_s_log read-only .
   methods add
     importing
       obj_to_log    type any optional
@@ -11,7 +14,7 @@ interface zif_logger
       importance    type balprobcl optional
         preferred parameter obj_to_log
     returning
-      value(self)   type ref to zcl_logger .
+      value(self)   type ref to zif_logger .
   methods a
     importing
       obj_to_log    type any optional
@@ -22,7 +25,7 @@ interface zif_logger
       importance    type balprobcl optional
         preferred parameter obj_to_log
     returning
-      value(self)   type ref to zcl_logger .
+      value(self)   type ref to zif_logger .
   methods e
     importing
       obj_to_log    type any optional
@@ -33,7 +36,7 @@ interface zif_logger
       importance    type balprobcl optional
         preferred parameter obj_to_log
     returning
-      value(self)   type ref to zcl_logger .
+      value(self)   type ref to zif_logger .
   methods w
     importing
       obj_to_log    type any optional
@@ -44,7 +47,7 @@ interface zif_logger
       importance    type balprobcl optional
         preferred parameter obj_to_log
     returning
-      value(self)   type ref to zcl_logger .
+      value(self)   type ref to zif_logger .
   methods i
     importing
       obj_to_log    type any optional
@@ -55,7 +58,7 @@ interface zif_logger
       importance    type balprobcl optional
         preferred parameter obj_to_log
     returning
-      value(self)   type ref to zcl_logger .
+      value(self)   type ref to zif_logger .
   methods s
     importing
       obj_to_log    type any optional
@@ -66,7 +69,7 @@ interface zif_logger
       importance    type balprobcl optional
         preferred parameter obj_to_log
     returning
-      value(self)   type ref to zcl_logger .
+      value(self)   type ref to zif_logger .
   methods save .
   methods get_autosave
     returning

--- a/zif_logger.intf.abap
+++ b/zif_logger.intf.abap
@@ -1,0 +1,83 @@
+interface zif_logger
+  public .
+  methods add
+    importing
+      obj_to_log    type any optional
+      context       type simple optional
+      callback_form type csequence optional
+      callback_prog type csequence optional
+      callback_fm   type csequence optional
+      type          type symsgty optional
+      importance    type balprobcl optional
+        preferred parameter obj_to_log
+    returning
+      value(self)   type ref to zcl_logger .
+  methods a
+    importing
+      obj_to_log    type any optional
+      context       type simple optional
+      callback_form type csequence optional
+      callback_prog type csequence optional
+      callback_fm   type csequence optional
+      importance    type balprobcl optional
+        preferred parameter obj_to_log
+    returning
+      value(self)   type ref to zcl_logger .
+  methods e
+    importing
+      obj_to_log    type any optional
+      context       type simple optional
+      callback_form type csequence optional
+      callback_prog type csequence optional
+      callback_fm   type csequence optional
+      importance    type balprobcl optional
+        preferred parameter obj_to_log
+    returning
+      value(self)   type ref to zcl_logger .
+  methods w
+    importing
+      obj_to_log    type any optional
+      context       type simple optional
+      callback_form type csequence optional
+      callback_prog type csequence optional
+      callback_fm   type csequence optional
+      importance    type balprobcl optional
+        preferred parameter obj_to_log
+    returning
+      value(self)   type ref to zcl_logger .
+  methods i
+    importing
+      obj_to_log    type any optional
+      context       type simple optional
+      callback_form type csequence optional
+      callback_prog type csequence optional
+      callback_fm   type csequence optional
+      importance    type balprobcl optional
+        preferred parameter obj_to_log
+    returning
+      value(self)   type ref to zcl_logger .
+  methods s
+    importing
+      obj_to_log    type any optional
+      context       type simple optional
+      callback_form type csequence optional
+      callback_prog type csequence optional
+      callback_fm   type csequence optional
+      importance    type balprobcl optional
+        preferred parameter obj_to_log
+    returning
+      value(self)   type ref to zcl_logger .
+  methods save .
+  methods get_autosave
+    returning
+      value(auto_save) type abap_bool .
+  methods set_autosave
+    importing
+      auto_save type abap_bool .
+  methods export_to_table
+    returning
+      value(rt_bapiret) type bapirettab .
+  methods fullscreen .
+  methods popup .
+
+endinterface.

--- a/zif_logger.intf.xml
+++ b/zif_logger.intf.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_INTF" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOINTERF>
+    <CLSNAME>ZIF_LOGGER</CLSNAME>
+    <VERSION>1</VERSION>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Logger Interface</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <UNICODE>X</UNICODE>
+   </VSEOINTERF>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
I moved public instance methods to an interface to be able to mock it in unit tests.
For backwards compatibility I creates aliases for the extracted methods.
I accidentally closed the first pull request.