### PR TITLE
#23 change initial to supplied

### DIFF
--- a/zcl_logger.clas.abap
+++ b/zcl_logger.clas.abap
@@ -207,7 +207,7 @@ CLASS ZCL_LOGGER IMPLEMENTATION.
 
     msg_type = cl_abap_typedescr=>describe_by_data( obj_to_log ).
 
-    if obj_to_log is initial.
+    if obj_to_log is not supplied.
       detailed_msg-msgty = sy-msgty.
       detailed_msg-msgid = sy-msgid.
       detailed_msg-msgno = sy-msgno.


### PR DESCRIPTION
Hi,

I would suggest to change the following line:

if obj_to_log is initial.
https://github.com/epeterson320/ABAP-Logger/blob/master/zcl_logger.clas.abap#L210

to

if obj_to_log is not supplied.
Otherwise a message is created if an empty return table is passed to the method.


Tests are still passing

Regards,
Timo