### PR TITLE
Ensure full backwards compatibility

### DIFF
--- a/zcl_logger.clas.abap
+++ b/zcl_logger.clas.abap
@@ -40,7 +40,7 @@ class zcl_logger definition
         !auto_save      type abap_bool optional
         !second_db_conn type abap_bool default abap_true
       returning
-        value(r_log)    type ref to zif_logger .
+        value(r_log)    type ref to zcl_logger .
 
     " backwards compatibility only -> use zcl_logger_factory instead
     class-methods open
@@ -51,7 +51,7 @@ class zcl_logger definition
         !create_if_does_not_exist type abap_bool default abap_false
         !auto_save                type abap_bool optional
       returning
-        value(r_log)              type ref to zif_logger .
+        value(r_log)              type ref to zcl_logger .
 
   protected section.
 *"* protected components of class ZCL_LOGGER
@@ -342,22 +342,22 @@ class zcl_logger implementation.
   method new.
 
     if auto_save is supplied.
-      r_log = zcl_logger_factory=>create_log(
+      r_log = cast zcl_logger( zcl_logger_factory=>create_log(
         !object = object
         !subobject = subobject
         !desc = desc
         !context = context
         !auto_save = auto_save
         !second_db_conn = second_db_conn
-      ).
+      ) ).
     else.
-      r_log = zcl_logger_factory=>create_log(
+      r_log = cast zcl_logger( zcl_logger_factory=>create_log(
         !object = object
         !subobject = subobject
         !desc = desc
         !context = context
         !second_db_conn = second_db_conn
-      ).
+      ) ).
     endif.
 
   endmethod.
@@ -366,20 +366,20 @@ class zcl_logger implementation.
   method open.
 
     if auto_save is supplied.
-      r_log = zcl_logger_factory=>open_log(
+      r_log = cast zcl_logger( zcl_logger_factory=>open_log(
         !object = object
         !subobject = subobject
         !desc = desc
         !create_if_does_not_exist = create_if_does_not_exist
         !auto_save = auto_save
-      ).
+      ) ).
     else.
-      r_log = zcl_logger_factory=>open_log(
+      r_log = cast zcl_logger( zcl_logger_factory=>open_log(
         !object = object
         !subobject = subobject
         !desc = desc
         !create_if_does_not_exist = create_if_does_not_exist
-      ).
+      ) ).
     endif.
 
   endmethod.

--- a/zcl_logger.clas.xml
+++ b/zcl_logger.clas.xml
@@ -131,7 +131,7 @@
     </TLINE>
     <TLINE>
      <TDFORMAT>=</TDFORMAT>
-     <TDLINE> &lt;DS:RE.SAPLSBAL&gt;SBAL&lt;/&gt;.</TDLINE>
+     <TDLINE>&lt;DS:RE.SAPLSBAL&gt;SBAL&lt;/&gt;.</TDLINE>
     </TLINE>
     <TLINE>
      <TDFORMAT>U1</TDFORMAT>
@@ -174,11 +174,11 @@
     </TLINE>
     <TLINE>
      <TDFORMAT>/</TDFORMAT>
-     <TDLINE>                       subobject = &apos;NOTIFICATIONS&apos;</TDLINE>
+     <TDLINE>subobject = &apos;NOTIFICATIONS&apos;</TDLINE>
     </TLINE>
     <TLINE>
      <TDFORMAT>/</TDFORMAT>
-     <TDLINE>                       desc = |Notifications on { sy-datum }| ).</TDLINE>
+     <TDLINE>desc = |Notifications on { sy-datum }| ).</TDLINE>
     </TLINE>
     <TLINE>
      <TDFORMAT>U3</TDFORMAT>
@@ -210,7 +210,7 @@
     </TLINE>
     <TLINE>
      <TDFORMAT>/</TDFORMAT>
-     <TDLINE>      l_err TYPE REF TO zcx_operation_failed.</TDLINE>
+     <TDLINE>l_err TYPE REF TO zcx_operation_failed.</TDLINE>
     </TLINE>
     <TLINE>
      <TDFORMAT>/</TDFORMAT>
@@ -222,15 +222,15 @@
     </TLINE>
     <TLINE>
      <TDFORMAT>/</TDFORMAT>
-     <TDLINE>    my_class=&gt;do_some_operation( ).</TDLINE>
+     <TDLINE>my_class=&gt;do_some_operation( ).</TDLINE>
     </TLINE>
     <TLINE>
      <TDFORMAT>/</TDFORMAT>
-     <TDLINE>  CATCH zcx_operation_failed INTO l_err.</TDLINE>
+     <TDLINE>CATCH zcx_operation_failed INTO l_err.</TDLINE>
     </TLINE>
     <TLINE>
      <TDFORMAT>/</TDFORMAT>
-     <TDLINE>    log-&gt;e( l_err ).</TDLINE>
+     <TDLINE>log-&gt;e( l_err ).</TDLINE>
     </TLINE>
     <TLINE>
      <TDFORMAT>/</TDFORMAT>
@@ -250,23 +250,23 @@
     </TLINE>
     <TLINE>
      <TDFORMAT>/</TDFORMAT>
-     <TDLINE>  EXPORTING</TDLINE>
+     <TDLINE>EXPORTING</TDLINE>
     </TLINE>
     <TLINE>
      <TDFORMAT>/</TDFORMAT>
-     <TDLINE>    parameter1 = foo</TDLINE>
+     <TDLINE>parameter1 = foo</TDLINE>
     </TLINE>
     <TLINE>
      <TDFORMAT>/</TDFORMAT>
-     <TDLINE>    parameter2 = bar</TDLINE>
+     <TDLINE>parameter2 = bar</TDLINE>
     </TLINE>
     <TLINE>
      <TDFORMAT>/</TDFORMAT>
-     <TDLINE>  TABLES</TDLINE>
+     <TDLINE>TABLES</TDLINE>
     </TLINE>
     <TLINE>
      <TDFORMAT>/</TDFORMAT>
-     <TDLINE>    return = rtn_msgs.</TDLINE>
+     <TDLINE>return = rtn_msgs.</TDLINE>
     </TLINE>
     <TLINE>
      <TDFORMAT>/</TDFORMAT>
@@ -274,14 +274,14 @@
     </TLINE>
     <TLINE>
      <TDFORMAT>/</TDFORMAT>
-     <TDLINE>  log = zcl_logger=&gt;new( object = &apos;ACCOUNTING&apos; subobject = &apos;INTERFACES&apos;</TDLINE>
+     <TDLINE>log = zcl_logger=&gt;new( object = &apos;ACCOUNTING&apos; subobject = &apos;INTERFACES&apos;</TDLINE>
     </TLINE>
     <TLINE>
      <TDLINE>).</TDLINE>
     </TLINE>
     <TLINE>
      <TDFORMAT>/</TDFORMAT>
-     <TDLINE>  log-&gt;add( rtn_msgs ).</TDLINE>
+     <TDLINE>log-&gt;add( rtn_msgs ).</TDLINE>
     </TLINE>
     <TLINE>
      <TDFORMAT>/</TDFORMAT>


### PR DESCRIPTION
Methods new and open which were left for compatibility reasons return a zif_logger object which did not exist before the creation of factory branch.

Programs coded with the master-branch of ABAP-Logger work as expected with this PR.

Incidentally, this would allow to merge factory with master to make further maintenance easier.

BR