### PR TITLE
Log previous exception as well

### DIFF
--- a/zcl_logger.clas.abap
+++ b/zcl_logger.clas.abap
@@ -57,9 +57,6 @@ class zcl_logger definition
 *"* protected components of class ZCL_LOGGER
 *"* do not include other source files here!!!
   private section.
-
-    constants: c_max_exception_drill_down type i value 10.
-
 * Local type for hrpad_message as it is not available in an ABAP Development System
     types: begin of hrpad_message_field_list_alike,
              scrrprfd type scrrprfd.
@@ -78,6 +75,7 @@ class zcl_logger definition
     data auto_save          type abap_bool .
     data sec_connection     type abap_bool .
     data sec_connect_commit type abap_bool .
+    data: max_exception_drill_down type i.
 
     methods:
       drill_down_into_exception importing exception                      type ref to cx_root
@@ -492,7 +490,7 @@ class zcl_logger implementation.
 
     previous_exception = exception.
 
-    while i <= c_max_exception_drill_down.
+    while i <= max_exception_drill_down.
       if previous_exception->previous is not bound.
         exit.
       endif.

--- a/zcl_logger.clas.locals_def.abap
+++ b/zcl_logger.clas.locals_def.abap
@@ -1,0 +1,11 @@
+*"* use this source file for any type of declarations (class
+*"* definitions, interfaces or type declarations) you need for
+*"* components in the private section
+
+types: begin of ty_exception,
+         level     type i,
+         exception type ref to cx_root,
+       end of ty_exception,
+       tty_exception type standard table of ty_exception.
+
+types: tty_exception_data    type standard table of bal_s_exc with default key.

--- a/zcl_logger.clas.locals_imp.abap
+++ b/zcl_logger.clas.locals_imp.abap
@@ -1,0 +1,31 @@
+class lcx_t100 definition inheriting from cx_static_check.
+  public section.
+    interfaces if_t100_message.
+    methods constructor importing previous like previous optional
+                                  id       type symsgid
+                                  no       type symsgno
+                                  msgv1    type syst_msgv optional
+                                  msgv2    type syst_msgv optional
+                                  msgv3    type syst_msgv optional
+                                  msgv4    type syst_msgv optional.
+    data msgv1 type syst_msgv.
+    data msgv2 type syst_msgv.
+    data msgv3 type syst_msgv.
+    data msgv4 type syst_msgv.
+endclass.
+
+class lcx_t100 implementation.
+  method constructor.
+    super->constructor( previous = previous ).
+    me->msgv1                     = msgv1.
+    me->msgv2                     = msgv2.
+    me->msgv3                     = msgv3.
+    me->msgv4                     = msgv4.
+    if_t100_message~t100key-msgid = id.
+    if_t100_message~t100key-msgno = no.
+    if_t100_message~t100key-attr1 = 'MSGV1'.
+    if_t100_message~t100key-attr2 = 'MSGV2'.
+    if_t100_message~t100key-attr3 = 'MSGV3'.
+    if_t100_message~t100key-attr4 = 'MSGV4'.
+  endmethod.
+endclass.

--- a/zcl_logger_factory.clas.abap
+++ b/zcl_logger_factory.clas.abap
@@ -7,14 +7,15 @@ class zcl_logger_factory definition
 
     class-methods create_log
       importing
-        !object         type csequence optional
-        !subobject      type csequence optional
-        !desc           type csequence optional
-        !context        type simple optional
-        !auto_save      type abap_bool optional
-        !second_db_conn type abap_bool default abap_true
+        !object                  type csequence optional
+        !subobject               type csequence optional
+        !desc                    type csequence optional
+        !context                 type simple optional
+        !auto_save               type abap_bool optional
+        !second_db_conn          type abap_bool default abap_true
+        max_exception_drill_down type i default 10
       returning
-        value(r_log)    type ref to zif_logger .
+        value(r_log)             type ref to zif_logger .
 
     class-methods open_log
       importing
@@ -47,7 +48,7 @@ class zcl_logger_factory implementation.
     field-symbols <context_val> type c.
 
     create object lo_log.
-    lo_log->header-object = object.
+    lo_log->header-object    = object.
     lo_log->header-subobject = subobject.
     lo_log->header-extnumber = desc.
 
@@ -64,9 +65,12 @@ class zcl_logger_factory implementation.
 * Use secondary database connection to write data to database even if
 * main program does a rollback (e. g. during a dump).
     if second_db_conn = abap_true.
-      lo_log->sec_connection = abap_true.
+      lo_log->sec_connection     = abap_true.
       lo_log->sec_connect_commit = abap_true.
     endif.
+
+* Safety limit for previous exception drill down
+    lo_log->max_exception_drill_down = max_exception_drill_down.
 
     if context is supplied and context is not initial.
       lo_log->header-context-tabname =
@@ -103,18 +107,18 @@ class zcl_logger_factory implementation.
 *-- The SAVE method must be called at the end processing
 *-- to save all of the log data
 
-    data: filter             type bal_s_lfil,
-          desc_filter        type bal_s_extn,
-          obj_filter         type bal_s_obj,
-          subobj_filter      type bal_s_sub,
+    data: filter        type bal_s_lfil,
+          desc_filter   type bal_s_extn,
+          obj_filter    type bal_s_obj,
+          subobj_filter type bal_s_sub,
 
           found_headers      type balhdr_t,
           most_recent_header type balhdr,
           handles_loaded     type bal_t_logh.
-    data: lo_log type ref to zcl_logger.
+    data: lo_log             type ref to zcl_logger.
 
     desc_filter-option = subobj_filter-option = obj_filter-option = 'EQ'.
-    desc_filter-sign = subobj_filter-sign = obj_filter-sign = 'I'.
+    desc_filter-sign   = subobj_filter-sign = obj_filter-sign = 'I'.
 
     obj_filter-low = object.
     append obj_filter to filter-object.
@@ -159,7 +163,7 @@ class zcl_logger_factory implementation.
     endif.
 
     lo_log->db_number = most_recent_header-lognumber.
-    lo_log->handle = most_recent_header-log_handle.
+    lo_log->handle    = most_recent_header-log_handle.
 
     call function 'BAL_DB_LOAD'
       exporting


### PR DESCRIPTION
When I log an exception that contains chained exceptions (``raise exception type zcx_new_exception exporting previous=catched_exception.``), I would like to log them all.

In this PR, I added a method that drills into previous exception (up to 10 chained exceptions cf. ``c_max_exception_drill_down``), put them into chronological order and returns a table with all data.  

Later we loop at the table and call ``BAL_LOG_EXCEPTION_ADD``

BR,
Alexandre
