### PR TITLE
Fix language parameter in format_message method

### DIFF
--- a/zcl_logger.clas.testclasses.abap
+++ b/zcl_logger.clas.testclasses.abap
@@ -904,7 +904,7 @@ class lcl_test implementation.
     call function 'FORMAT_MESSAGE'
       exporting
         id        = id
-        lang      = lang
+        lang      = 'E'
         no        = no
         v1        = v1
         v2        = v2


### PR DESCRIPTION
Set the language as a fixed value('E') to FORMAT_MESSAGE FM to avoid error on the unit tests when the system language is other than English(E) ou German(D).