### PR TITLE
downport to 731

### DIFF
--- a/zcl_logger.clas.locals_imp.abap
+++ b/zcl_logger.clas.locals_imp.abap
@@ -4,14 +4,14 @@ class lcx_t100 definition inheriting from cx_static_check.
     methods constructor importing previous like previous optional
                                   id       type symsgid
                                   no       type symsgno
-                                  msgv1    type syst_msgv optional
-                                  msgv2    type syst_msgv optional
-                                  msgv3    type syst_msgv optional
-                                  msgv4    type syst_msgv optional.
-    data msgv1 type syst_msgv.
-    data msgv2 type syst_msgv.
-    data msgv3 type syst_msgv.
-    data msgv4 type syst_msgv.
+                                  msgv1    type symsgv optional
+                                  msgv2    type symsgv optional
+                                  msgv3    type symsgv optional
+                                  msgv4    type symsgv optional.
+    data msgv1 type symsgv.
+    data msgv2 type symsgv.
+    data msgv3 type symsgv.
+    data msgv4 type symsgv.
 endclass.
 
 class lcx_t100 implementation.

--- a/zcl_logger.clas.testclasses.abap
+++ b/zcl_logger.clas.testclasses.abap
@@ -572,6 +572,7 @@ class lcl_test implementation.
           err            type ref to cx_sy_zerodivide,
           act_txt        type char255,
           exp_txt        type char255,
+          long_text      type string,
           msg_handle     type balmsghndl.
 
     try.
@@ -579,7 +580,7 @@ class lcl_test implementation.
       catch cx_sy_zerodivide into err.
         anon_log->add( err ).
         exp_txt         = err->if_message~get_text( ).
-        data(long_text) = err->if_message~get_longtext( ).
+        long_text       = err->if_message~get_longtext( ).
     endtry.
 
     msg_handle-log_handle = anon_log->handle.
@@ -600,20 +601,21 @@ class lcl_test implementation.
   method can_log_chained_exceptions.
     data: main_exception     type ref to lcx_t100,
           previous_exception type ref to lcx_t100,
+          catched_exception  type ref to lcx_t100,
           msg_handle         type balmsghndl,
           act_texts          type table_of_strings,
           act_text           type string.
 
     define exceptions_are.
-      main_exception = new lcx_t100(
+      create object main_exception
+        exporting
           previous = previous_exception
           id       = &1
           no       = &2
           msgv1    = &3
           msgv2    = &4
           msgv3    = &5
-          msgv4    = &6
-      ).
+          msgv4    = &6.
       previous_exception = main_exception.
     end-of-definition.
 
@@ -627,7 +629,7 @@ class lcl_test implementation.
     "When
     try.
         raise exception main_exception.
-      catch lcx_t100 into data(catched_exception).
+      catch lcx_t100 into catched_exception.
         anon_log->add( catched_exception ).
     endtry.
 


### PR DESCRIPTION
Hi !
recent updates added some 74 syntax lines ... and it stopped working in 702, 731
here is a downport

P.S. `drill_down_into_exception` has minor downport related changes - but it was moved by se80 activation so it appears to be removed/added.