### PR TITLE
Logger for XPRA reports & change of application log sub-object to customer name space

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,11 @@ CALL FUNCTION 'BAL_LOG_MSG_CUMULATE'
     i_compare_attributes = abap_true.
 ```
 
+## Logging in XPRA reports
+If your report is executed as an XPRA report you can still use this logger. 
+The logger factory will create an object that adds messages to the transport log if called during an XPRA execution.
+Restrictions: The XPRA logger does not store context information, and callback information is not relevant.
+
 ## Installation
 
 1. Install this project via [ABAPGit](http://abapgit.org).

--- a/package.devc.xml
+++ b/package.devc.xml
@@ -4,6 +4,8 @@
   <asx:values>
    <DEVC>
     <CTEXT>ABAP-Logger</CTEXT>
+    <COMP_POSID>BC</COMP_POSID>
+    <COMPONENT>HLB0009009</COMPONENT>
    </DEVC>
   </asx:values>
  </asx:abap>

--- a/zcl_logger.clas.abap
+++ b/zcl_logger.clas.abap
@@ -90,8 +90,8 @@ ENDCLASS.
 CLASS ZCL_LOGGER IMPLEMENTATION.
 
 
-  method a.
-    self = add(
+  method zif_logger~a.
+    self = zif_logger~add(
       obj_to_log    = obj_to_log
       context       = context
       callback_form = callback_form
@@ -102,7 +102,7 @@ CLASS ZCL_LOGGER IMPLEMENTATION.
   endmethod.
 
 
-  method add.
+  method zif_logger~add.
 
     data: detailed_msg         type bal_s_msg,
           exception_data_table type tty_exception_data,
@@ -326,8 +326,8 @@ CLASS ZCL_LOGGER IMPLEMENTATION.
   endmethod.
 
 
-  method e.
-    self = add(
+  method zif_logger~e.
+    self = zif_logger~add(
       obj_to_log    = obj_to_log
       context       = context
       callback_form = callback_form
@@ -338,7 +338,7 @@ CLASS ZCL_LOGGER IMPLEMENTATION.
   endmethod.
 
 
-  method export_to_table.
+  method zif_logger~export_to_table.
     data: log_handle      type bal_t_logh,
           message_handles type bal_t_msgh,
           message         type bal_s_msg,
@@ -388,7 +388,7 @@ CLASS ZCL_LOGGER IMPLEMENTATION.
   endmethod.
 
 
-  method fullscreen.
+  method zif_logger~fullscreen.
 
     data:
           profile        type bal_s_prof,
@@ -408,15 +408,15 @@ CLASS ZCL_LOGGER IMPLEMENTATION.
   endmethod.
 
 
-  method get_autosave.
+  method zif_logger~get_autosave.
 
     auto_save = me->auto_save.
 
   endmethod.
 
 
-  method i.
-    self = add(
+  method zif_logger~i.
+    self = zif_logger~add(
       obj_to_log    = obj_to_log
       context       = context
       callback_form = callback_form
@@ -473,7 +473,7 @@ CLASS ZCL_LOGGER IMPLEMENTATION.
   endmethod.
 
 
-  method popup.
+  method zif_logger~popup.
 * See SBAL_DEMO_04_POPUP for ideas
 
     data:
@@ -494,8 +494,8 @@ CLASS ZCL_LOGGER IMPLEMENTATION.
   endmethod.
 
 
-  method s.
-    self = add(
+  method zif_logger~s.
+    self = zif_logger~add(
       obj_to_log    = obj_to_log
       context       = context
       callback_form = callback_form
@@ -506,7 +506,7 @@ CLASS ZCL_LOGGER IMPLEMENTATION.
   endmethod.
 
 
-  method save.
+  method zif_logger~save.
 *--------------------------------------------------------------------*
 * Method to save the log on demand.  Intended to be called at the    *
 *  end of the log processing so that logs can be saved depending     *
@@ -539,15 +539,15 @@ CLASS ZCL_LOGGER IMPLEMENTATION.
   endmethod.
 
 
-  method set_autosave.
+  method zif_logger~set_autosave.
 
     me->auto_save = auto_save.
 
   endmethod.
 
 
-  method w.
-    self = add(
+  method zif_logger~w.
+    self = zif_logger~add(
       obj_to_log    = obj_to_log
       context       = context
       callback_form = callback_form

--- a/zcl_logger.clas.testclasses.abap
+++ b/zcl_logger.clas.testclasses.abap
@@ -22,6 +22,8 @@ class lcl_test definition for testing
 *?</asx:values>
 *?</asx:abap>
   private section.
+    constants c_bal_object type string value 'ABAPUNIT' ##no_text.
+    constants c_bal_subobject type string value 'ZCL_LOGGER' ##no_text.
 
     data:
           anon_log     type ref to zif_logger,
@@ -94,18 +96,18 @@ class lcl_test implementation.
 
   method class_setup.
     zcl_logger=>new(
-      object = 'ABAPUNIT'
-      subobject = 'LOGGER'
+      object = c_bal_object
+      subobject = c_bal_subobject
       desc = 'Log saved in database' )->add( 'This message is in the database' ).
   endmethod.
 
   method setup.
     anon_log  = zcl_logger=>new( ).
-    named_log = zcl_logger=>new( object = 'ABAPUNIT'
-                                 subobject = 'LOGGER'
+    named_log = zcl_logger=>new( object = c_bal_object
+                                 subobject = c_bal_subobject
                                  desc = `Hey it's a log` ).
-    reopened_log = zcl_logger=>open( object = 'ABAPUNIT'
-                                     subobject = 'LOGGER'
+    reopened_log = zcl_logger=>open( object = c_bal_object
+                                     subobject = c_bal_subobject
                                      desc = 'Log saved in database' ).
   endmethod.
 
@@ -131,12 +133,12 @@ class lcl_test implementation.
     data: created_log type ref to zif_logger,
           handles     type bal_t_logh.
     call function 'BAL_GLB_MEMORY_REFRESH'.                "Close Logs
-    reopened_log = zcl_logger=>open( object = 'ABAPUNIT'
-                                     subobject = 'LOGGER'
+    reopened_log = zcl_logger=>open( object = c_bal_object
+                                     subobject = c_bal_subobject
                                      desc = 'Log saved in database'
                                      create_if_does_not_exist = abap_true ).
-    created_log = zcl_logger=>open( object = 'ABAPUNIT'
-                                    subobject = 'LOGGER'
+    created_log = zcl_logger=>open( object = c_bal_object
+                                    subobject = c_bal_subobject
                                     desc = 'Log not in database'
                                     create_if_does_not_exist = abap_true ).
     call function 'BAL_GLB_SEARCH_LOG'

--- a/zcl_logger.clas.xml
+++ b/zcl_logger.clas.xml
@@ -4,7 +4,6 @@
   <asx:values>
    <VSEOCLASS>
     <CLSNAME>ZCL_LOGGER</CLSNAME>
-    <VERSION>1</VERSION>
     <LANGU>E</LANGU>
     <DESCRIPT>Logger</DESCRIPT>
     <STATE>1</STATE>

--- a/zcl_logger_factory.clas.abap
+++ b/zcl_logger_factory.clas.abap
@@ -1,3 +1,4 @@
+"! <p class="shorttext synchronized" lang="en">Logger Factory</p>
 class zcl_logger_factory definition
   public
   final
@@ -28,7 +29,16 @@ class zcl_logger_factory definition
         value(r_log)              type ref to zif_logger .
 
   protected section.
+    "! <p class="shorttext synchronized" lang="en">Is this program executed as XPRA report</p>
+    "!
+    "! @parameter r_xpra_execution | <p class="shorttext synchronized" lang="en">true if executing as XPRA</p>
+    class-methods is_xpra_execution
+      returning
+        value(r_xpra_execution) type abap_bool.
+
   private section.
+    "! <p class="shorttext synchronized" lang="en">Name of background job which executes XPRA reports</p>
+    constants c_xpra_job_name type btcjob value 'RDDEXECL' ##no_text.
 endclass.
 
 
@@ -44,56 +54,68 @@ class zcl_logger_factory implementation.
 *-- The SAVE method must be called at the end processing
 *-- to save all of the log data
 
-    data: lo_log type ref to zcl_logger.
-    field-symbols <context_val> type c.
+    if is_xpra_execution(  ) = abap_true.
+      data(lo_xpra_logger) = new zcl_logger_xpra( ).
 
-    create object lo_log.
-    lo_log->header-object    = object.
-    lo_log->header-subobject = subobject.
-    lo_log->header-extnumber = desc.
+      if auto_save is supplied.
+        lo_xpra_logger->auto_save = auto_save.
+      else.
+        lo_xpra_logger->auto_save = abap_true.
+      endif.
 
+      r_log = lo_xpra_logger.
+
+    else. "Standard (application) log
+      data: lo_log type ref to zcl_logger.
+      field-symbols <context_val> type c.
+
+      create object lo_log.
+      lo_log->header-object    = object.
+      lo_log->header-subobject = subobject.
+      lo_log->header-extnumber = desc.
 *-- If AUTO_SAVE is not passed in, then use the old logic
 *-- This is to ensure backwards compatiblilty
-    if auto_save is supplied.
-      lo_log->auto_save = auto_save.
-    else.
-      if object is not initial and subobject is not initial.
-        lo_log->auto_save = abap_true.
+      if auto_save is supplied.
+        lo_log->auto_save = auto_save.
+      else.
+        if object is not initial and subobject is not initial.
+          lo_log->auto_save = abap_true.
+        endif.
       endif.
-    endif.
 
 * Use secondary database connection to write data to database even if
 * main program does a rollback (e. g. during a dump).
-    if second_db_conn = abap_true.
-      lo_log->sec_connection     = abap_true.
-      lo_log->sec_connect_commit = abap_true.
-    endif.
+      if second_db_conn = abap_true.
+        lo_log->sec_connection     = abap_true.
+        lo_log->sec_connect_commit = abap_true.
+      endif.
 
 * Safety limit for previous exception drill down
-    lo_log->max_exception_drill_down = max_exception_drill_down.
+      lo_log->max_exception_drill_down = max_exception_drill_down.
 
-    if context is supplied and context is not initial.
-      lo_log->header-context-tabname =
-        cl_abap_typedescr=>describe_by_data( context )->get_ddic_header( )-tabname.
-      assign context to <context_val> casting.
-      lo_log->header-context-value = <context_val>.
-    endif.
+      if context is supplied and context is not initial.
+        lo_log->header-context-tabname =
+          cl_abap_typedescr=>describe_by_data( context )->get_ddic_header( )-tabname.
+        assign context to <context_val> casting.
+        lo_log->header-context-value = <context_val>.
+      endif.
 
-    call function 'BAL_LOG_CREATE'
-      exporting
-        i_s_log      = lo_log->header
-      importing
-        e_log_handle = lo_log->handle.
+      call function 'BAL_LOG_CREATE'
+        exporting
+          i_s_log      = lo_log->header
+        importing
+          e_log_handle = lo_log->handle.
 
 * BAL_LOG_CREATE will fill in some additional header data.
 * This FM updates our instance attribute to reflect that.
-    call function 'BAL_LOG_HDR_READ'
-      exporting
-        i_log_handle = lo_log->handle
-      importing
-        e_s_log      = lo_log->header.
+      call function 'BAL_LOG_HDR_READ'
+        exporting
+          i_log_handle = lo_log->handle
+        importing
+          e_s_log      = lo_log->header.
 
-    r_log = lo_log.
+      r_log = lo_log.
+    endif.
 
   endmethod.
 
@@ -177,6 +199,30 @@ class zcl_logger_factory implementation.
 
     r_log = lo_log.
 
+  endmethod.
+
+
+  method is_xpra_execution.
+* XPRA executes in client 000 in a specific job
+    data current_job_name type btcjob.
+
+    r_xpra_execution = abap_false.
+    if sy-mandt <> '000'.
+      return.
+    endif.
+
+    call function 'GET_JOB_RUNTIME_INFO'
+      importing
+        jobname         = current_job_name
+      exceptions
+        no_runtime_info = 1.
+    if sy-subrc <> 0.
+      return.
+    endif.
+
+    if current_job_name = c_xpra_job_name.
+      r_xpra_execution = abap_true.
+    endif.
   endmethod.
 
 endclass.

--- a/zcl_logger_factory.clas.abap
+++ b/zcl_logger_factory.clas.abap
@@ -1,4 +1,3 @@
-"! <p class="shorttext synchronized" lang="en">Logger Factory</p>
 class zcl_logger_factory definition
   public
   final
@@ -29,16 +28,7 @@ class zcl_logger_factory definition
         value(r_log)              type ref to zif_logger .
 
   protected section.
-    "! <p class="shorttext synchronized" lang="en">Is this program executed as XPRA report</p>
-    "!
-    "! @parameter r_xpra_execution | <p class="shorttext synchronized" lang="en">true if executing as XPRA</p>
-    class-methods is_xpra_execution
-      returning
-        value(r_xpra_execution) type abap_bool.
-
   private section.
-    "! <p class="shorttext synchronized" lang="en">Name of background job which executes XPRA reports</p>
-    constants c_xpra_job_name type btcjob value 'RDDEXECL' ##no_text.
 endclass.
 
 
@@ -54,68 +44,56 @@ class zcl_logger_factory implementation.
 *-- The SAVE method must be called at the end processing
 *-- to save all of the log data
 
-    if is_xpra_execution(  ) = abap_true.
-      data(lo_xpra_logger) = new zcl_logger_xpra( ).
+    data: lo_log type ref to zcl_logger.
+    field-symbols <context_val> type c.
 
-      if auto_save is supplied.
-        lo_xpra_logger->auto_save = auto_save.
-      else.
-        lo_xpra_logger->auto_save = abap_true.
-      endif.
+    create object lo_log.
+    lo_log->header-object    = object.
+    lo_log->header-subobject = subobject.
+    lo_log->header-extnumber = desc.
 
-      r_log = lo_xpra_logger.
-
-    else. "Standard (application) log
-      data: lo_log type ref to zcl_logger.
-      field-symbols <context_val> type c.
-
-      create object lo_log.
-      lo_log->header-object    = object.
-      lo_log->header-subobject = subobject.
-      lo_log->header-extnumber = desc.
 *-- If AUTO_SAVE is not passed in, then use the old logic
 *-- This is to ensure backwards compatiblilty
-      if auto_save is supplied.
-        lo_log->auto_save = auto_save.
-      else.
-        if object is not initial and subobject is not initial.
-          lo_log->auto_save = abap_true.
-        endif.
+    if auto_save is supplied.
+      lo_log->auto_save = auto_save.
+    else.
+      if object is not initial and subobject is not initial.
+        lo_log->auto_save = abap_true.
       endif.
+    endif.
 
 * Use secondary database connection to write data to database even if
 * main program does a rollback (e. g. during a dump).
-      if second_db_conn = abap_true.
-        lo_log->sec_connection     = abap_true.
-        lo_log->sec_connect_commit = abap_true.
-      endif.
+    if second_db_conn = abap_true.
+      lo_log->sec_connection     = abap_true.
+      lo_log->sec_connect_commit = abap_true.
+    endif.
 
 * Safety limit for previous exception drill down
-      lo_log->max_exception_drill_down = max_exception_drill_down.
+    lo_log->max_exception_drill_down = max_exception_drill_down.
 
-      if context is supplied and context is not initial.
-        lo_log->header-context-tabname =
-          cl_abap_typedescr=>describe_by_data( context )->get_ddic_header( )-tabname.
-        assign context to <context_val> casting.
-        lo_log->header-context-value = <context_val>.
-      endif.
+    if context is supplied and context is not initial.
+      lo_log->header-context-tabname =
+        cl_abap_typedescr=>describe_by_data( context )->get_ddic_header( )-tabname.
+      assign context to <context_val> casting.
+      lo_log->header-context-value = <context_val>.
+    endif.
 
-      call function 'BAL_LOG_CREATE'
-        exporting
-          i_s_log      = lo_log->header
-        importing
-          e_log_handle = lo_log->handle.
+    call function 'BAL_LOG_CREATE'
+      exporting
+        i_s_log      = lo_log->header
+      importing
+        e_log_handle = lo_log->handle.
 
 * BAL_LOG_CREATE will fill in some additional header data.
 * This FM updates our instance attribute to reflect that.
-      call function 'BAL_LOG_HDR_READ'
-        exporting
-          i_log_handle = lo_log->handle
-        importing
-          e_s_log      = lo_log->header.
+    call function 'BAL_LOG_HDR_READ'
+      exporting
+        i_log_handle = lo_log->handle
+      importing
+        e_s_log      = lo_log->header.
 
-      r_log = lo_log.
-    endif.
+    r_log = lo_log.
 
   endmethod.
 
@@ -199,30 +177,6 @@ class zcl_logger_factory implementation.
 
     r_log = lo_log.
 
-  endmethod.
-
-
-  method is_xpra_execution.
-* XPRA executes in client 000 in a specific job
-    data current_job_name type btcjob.
-
-    r_xpra_execution = abap_false.
-    if sy-mandt <> '000'.
-      return.
-    endif.
-
-    call function 'GET_JOB_RUNTIME_INFO'
-      importing
-        jobname         = current_job_name
-      exceptions
-        no_runtime_info = 1.
-    if sy-subrc <> 0.
-      return.
-    endif.
-
-    if current_job_name = c_xpra_job_name.
-      r_xpra_execution = abap_true.
-    endif.
   endmethod.
 
 endclass.

--- a/zcl_logger_factory.clas.xml
+++ b/zcl_logger_factory.clas.xml
@@ -11,6 +11,20 @@
     <FIXPT>X</FIXPT>
     <UNICODE>X</UNICODE>
    </VSEOCLASS>
+   <DESCRIPTIONS>
+    <SEOCOMPOTX>
+     <CLSNAME>ZCL_LOGGER_FACTORY</CLSNAME>
+     <CMPNAME>C_XPRA_JOB_NAME</CMPNAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>Name of background job which executes XPRA reports</DESCRIPT>
+    </SEOCOMPOTX>
+    <SEOCOMPOTX>
+     <CLSNAME>ZCL_LOGGER_FACTORY</CLSNAME>
+     <CMPNAME>EXECUTING_AS_XPRA</CMPNAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>Currently executing as an XPRA report?</DESCRIPT>
+    </SEOCOMPOTX>
+   </DESCRIPTIONS>
   </asx:values>
  </asx:abap>
 </abapGit>

--- a/zcl_logger_factory.clas.xml
+++ b/zcl_logger_factory.clas.xml
@@ -12,6 +12,20 @@
     <FIXPT>X</FIXPT>
     <UNICODE>X</UNICODE>
    </VSEOCLASS>
+   <DESCRIPTIONS>
+    <SEOCOMPOTX>
+     <CLSNAME>ZCL_LOGGER_FACTORY</CLSNAME>
+     <CMPNAME>C_XPRA_JOB_NAME</CMPNAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>Name of background job which executes XPRA reports</DESCRIPT>
+    </SEOCOMPOTX>
+    <SEOCOMPOTX>
+     <CLSNAME>ZCL_LOGGER_FACTORY</CLSNAME>
+     <CMPNAME>IS_XPRA_EXECUTION</CMPNAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>Is this program executed as XPRA report</DESCRIPT>
+    </SEOCOMPOTX>
+   </DESCRIPTIONS>
   </asx:values>
  </asx:abap>
 </abapGit>

--- a/zcl_logger_factory.clas.xml
+++ b/zcl_logger_factory.clas.xml
@@ -4,7 +4,6 @@
   <asx:values>
    <VSEOCLASS>
     <CLSNAME>ZCL_LOGGER_FACTORY</CLSNAME>
-    <VERSION>1</VERSION>
     <LANGU>E</LANGU>
     <DESCRIPT>Logger Factory</DESCRIPT>
     <STATE>1</STATE>
@@ -12,20 +11,6 @@
     <FIXPT>X</FIXPT>
     <UNICODE>X</UNICODE>
    </VSEOCLASS>
-   <DESCRIPTIONS>
-    <SEOCOMPOTX>
-     <CLSNAME>ZCL_LOGGER_FACTORY</CLSNAME>
-     <CMPNAME>C_XPRA_JOB_NAME</CMPNAME>
-     <LANGU>E</LANGU>
-     <DESCRIPT>Name of background job which executes XPRA reports</DESCRIPT>
-    </SEOCOMPOTX>
-    <SEOCOMPOTX>
-     <CLSNAME>ZCL_LOGGER_FACTORY</CLSNAME>
-     <CMPNAME>IS_XPRA_EXECUTION</CMPNAME>
-     <LANGU>E</LANGU>
-     <DESCRIPT>Is this program executed as XPRA report</DESCRIPT>
-    </SEOCOMPOTX>
-   </DESCRIPTIONS>
   </asx:values>
  </asx:abap>
 </abapGit>

--- a/zcl_logger_xpra.clas.abap
+++ b/zcl_logger_xpra.clas.abap
@@ -1,4 +1,4 @@
-"#autoformat (Pretty Print class automatically with abapCI plug-in (indent + all lower case)
+"#autoformat (Pretty Print class automatically with abapCI plug-in) setting: indent and all lower case
 "! <p class="shorttext synchronized" lang="en">Logger for XPRA reports - add messages to transport log</p>
 class zcl_logger_xpra definition
   public

--- a/zcl_logger_xpra.clas.abap
+++ b/zcl_logger_xpra.clas.abap
@@ -1,0 +1,445 @@
+"#autoformat (Pretty Print class automatically with abapCI plug-in (indent + all lower case)
+"! <p class="shorttext synchronized" lang="en">Logger for XPRA reports - add messages to transport log</p>
+class zcl_logger_xpra definition
+  public
+  create private
+  global friends zcl_logger_factory .
+
+  public section.
+    interfaces zif_logger_xpra.
+
+  protected section.
+* Local type for hrpad_message as it is not available in an ABAP Development System
+    types: begin of hrpad_message_field_list_alike,
+             scrrprfd type scrrprfd.
+    types: end of hrpad_message_field_list_alike.
+
+    types: begin of hrpad_message_alike,
+             cause(32)    type c,                          "original: hrpad_message_cause
+             detail_level type ballevel.
+        include type symsg .
+    types: field_list type standard table of hrpad_message_field_list_alike
+           with non-unique key scrrprfd.
+    types: end of hrpad_message_alike.
+
+    "! <p class="shorttext synchronized" lang="en">Create message from text string</p>
+    "!
+    "! @parameter message_text | <p class="shorttext synchronized" lang="en">Text string</p>
+    "! @parameter rs_message   | <p class="shorttext synchronized" lang="en">Message for log</p>
+    methods
+      message_from_string importing !i_message_text   type csequence
+                          returning value(rs_message) type sprot_u.
+    "! <p class="shorttext synchronized" lang="en"></p>
+    "!
+    "! @parameter is_message | <p class="shorttext synchronized" lang="en"></p>
+    "! @parameter rs_message | <p class="shorttext synchronized" lang="en"></p>
+    methods
+      message_from_bal_s_msg importing !is_message       type bal_s_msg
+                             returning value(rs_message) type sprot_u.
+
+  private section.
+    constants c_new_object type sprot_u-newobj value 'X'.
+
+    data  auto_save                type abap_bool .
+    data  sec_connection           type abap_bool .
+    data  sec_connect_commit       type abap_bool .
+    data: max_exception_drill_down type i.
+
+    methods:
+      drill_down_into_exception importing exception                      type ref to cx_root
+                                          type                           type symsgty optional
+                                          importance                     type balprobcl optional
+                                returning value(rt_exception_data_table) type tty_exception_data.
+
+
+    data handle type balloghndl.
+    data db_number type balognr.
+    data header type bal_s_log.
+
+    data mt_messages  type standard table of sprot_u with default key.
+    data m_new_object type sprot_u-newobj.
+endclass.
+
+
+
+class zcl_logger_xpra implementation.
+  method zif_logger_xpra~start_new_section.
+    m_new_object = c_new_object.
+  endmethod.
+
+
+  method zif_logger~a.
+    self = zif_logger~add( obj_to_log    = obj_to_log
+                           context       = context
+                           callback_form = callback_form
+                           callback_prog = callback_prog
+                           callback_fm   = callback_fm
+                           type          = 'A'
+                           importance    = importance ).
+  endmethod.
+
+
+  method zif_logger~e.
+    self = zif_logger~add( obj_to_log    = obj_to_log
+                           context       = context
+                           callback_form = callback_form
+                           callback_prog = callback_prog
+                           callback_fm   = callback_fm
+                           type          = 'E'
+                           importance    = importance ).
+  endmethod.
+
+
+  method zif_logger~w.
+    self = zif_logger~add( obj_to_log    = obj_to_log
+                           context       = context
+                           callback_form = callback_form
+                           callback_prog = callback_prog
+                           callback_fm   = callback_fm
+                           type          = 'W'
+                           importance    = importance ).
+  endmethod.
+
+
+  method zif_logger~i.
+    self = zif_logger~add( obj_to_log    = obj_to_log
+                           context       = context
+                           callback_form = callback_form
+                           callback_prog = callback_prog
+                           callback_fm   = callback_fm
+                           type          = 'I'
+                           importance    = importance ).
+  endmethod.
+
+
+  method zif_logger~s.
+    self = zif_logger~add( obj_to_log    = obj_to_log
+                           context       = context
+                           callback_form = callback_form
+                           callback_prog = callback_prog
+                           callback_fm   = callback_fm
+                           type          = 'S'
+                           importance    = importance ).
+  endmethod.
+
+
+  method zif_logger~add.
+    data: detailed_msg         type bal_s_msg,
+          exception_data_table type tty_exception_data,
+          free_text_msg        type char200,
+          ctx_type             type ref to cl_abap_typedescr,
+          ctx_ddic_header      type x030l,
+          msg_type             type ref to cl_abap_typedescr,
+          msg_table_type       type ref to cl_abap_tabledescr,
+          log_numbers          type bal_t_lgnm,
+          log_handles          type bal_t_logh,
+          log_number           type bal_s_lgnm,
+          formatted_context    type bal_s_cont,
+          formatted_params     type bal_s_parm.
+
+    field-symbols: <table_of_messages> type any table,
+                   <message_line>      type any,
+                   <bapiret1_msg>      type bapiret1,
+                   <bapi_msg>          type bapiret2,
+                   <bapi_coru_msg>     type bapi_coru_return,
+                   <bapi_order_msg>    type bapi_order_return,
+                   <bdc_msg>           type bdcmsgcoll,
+                   <hrpad_msg>         type hrpad_message_alike,
+                   <rcomp_msg>         type rcomp,
+                   <context_val>       type any.
+
+    if context is not initial.
+      assign context to <context_val>.
+      formatted_context-value = <context_val>.
+      ctx_type                = cl_abap_typedescr=>describe_by_data( context ).
+
+      call method ctx_type->get_ddic_header
+        receiving
+          p_header     = ctx_ddic_header
+        exceptions
+          not_found    = 1
+          no_ddic_type = 2
+          others       = 3.
+      if sy-subrc = 0.
+        formatted_context-tabname = ctx_ddic_header-tabname.
+      endif.
+    endif.
+
+    if callback_fm is not initial.
+      formatted_params-callback-userexitf = callback_fm.
+      formatted_params-callback-userexitp = callback_prog.
+      formatted_params-callback-userexitt = 'F'.
+    elseif callback_form is not initial.
+      formatted_params-callback-userexitf = callback_form.
+      formatted_params-callback-userexitp = callback_prog.
+      formatted_params-callback-userexitt = ' '.
+    endif.
+
+    msg_type = cl_abap_typedescr=>describe_by_data( obj_to_log ).
+
+    if obj_to_log is not supplied.
+      detailed_msg-msgty = sy-msgty.
+      detailed_msg-msgid = sy-msgid.
+      detailed_msg-msgno = sy-msgno.
+      detailed_msg-msgv1 = sy-msgv1.
+      detailed_msg-msgv2 = sy-msgv2.
+      detailed_msg-msgv3 = sy-msgv3.
+      detailed_msg-msgv4 = sy-msgv4.
+    elseif msg_type->type_kind = cl_abap_typedescr=>typekind_oref.
+      exception_data_table = me->drill_down_into_exception(
+          exception   = obj_to_log
+          type        = type
+          importance  = importance
+          ).
+    elseif msg_type->type_kind = cl_abap_typedescr=>typekind_table.
+      assign obj_to_log to <table_of_messages>.
+      loop at <table_of_messages> assigning <message_line>.
+        zif_logger~add( <message_line> ).
+      endloop.
+      return.
+    elseif msg_type->absolute_name = '\TYPE=BAPIRET1'.
+      assign obj_to_log to <bapiret1_msg>.
+      detailed_msg-msgty = <bapiret1_msg>-type.
+      detailed_msg-msgid = <bapiret1_msg>-id.
+      detailed_msg-msgno = <bapiret1_msg>-number.
+      detailed_msg-msgv1 = <bapiret1_msg>-message_v1.
+      detailed_msg-msgv2 = <bapiret1_msg>-message_v2.
+      detailed_msg-msgv3 = <bapiret1_msg>-message_v3.
+      detailed_msg-msgv4 = <bapiret1_msg>-message_v4.
+    elseif msg_type->absolute_name = '\TYPE=BAPIRET2'.
+      assign obj_to_log to <bapi_msg>.
+      detailed_msg-msgty = <bapi_msg>-type.
+      detailed_msg-msgid = <bapi_msg>-id.
+      detailed_msg-msgno = <bapi_msg>-number.
+      detailed_msg-msgv1 = <bapi_msg>-message_v1.
+      detailed_msg-msgv2 = <bapi_msg>-message_v2.
+      detailed_msg-msgv3 = <bapi_msg>-message_v3.
+      detailed_msg-msgv4 = <bapi_msg>-message_v4.
+    elseif msg_type->absolute_name = '\TYPE=BAPI_CORU_RETURN'.
+      assign obj_to_log to <bapi_coru_msg>.
+      detailed_msg-msgty = <bapi_coru_msg>-type.
+      detailed_msg-msgid = <bapi_coru_msg>-id.
+      detailed_msg-msgno = <bapi_coru_msg>-number.
+      detailed_msg-msgv1 = <bapi_coru_msg>-message_v1.
+      detailed_msg-msgv2 = <bapi_coru_msg>-message_v2.
+      detailed_msg-msgv3 = <bapi_coru_msg>-message_v3.
+      detailed_msg-msgv4 = <bapi_coru_msg>-message_v4.
+    elseif msg_type->absolute_name = '\TYPE=BAPI_ORDER_RETURN'.
+      assign obj_to_log to <bapi_order_msg>.
+      detailed_msg-msgty = <bapi_order_msg>-type.
+      detailed_msg-msgid = <bapi_order_msg>-id.
+      detailed_msg-msgno = <bapi_order_msg>-number.
+      detailed_msg-msgv1 = <bapi_order_msg>-message_v1.
+      detailed_msg-msgv2 = <bapi_order_msg>-message_v2.
+      detailed_msg-msgv3 = <bapi_order_msg>-message_v3.
+      detailed_msg-msgv4 = <bapi_order_msg>-message_v4.
+    elseif msg_type->absolute_name = '\TYPE=BDCMSGCOLL'.
+      assign obj_to_log to <bdc_msg>.
+      detailed_msg-msgty = <bdc_msg>-msgtyp.
+      detailed_msg-msgid = <bdc_msg>-msgid.
+      detailed_msg-msgno = <bdc_msg>-msgnr.
+      detailed_msg-msgv1 = <bdc_msg>-msgv1.
+      detailed_msg-msgv2 = <bdc_msg>-msgv2.
+      detailed_msg-msgv3 = <bdc_msg>-msgv3.
+      detailed_msg-msgv4 = <bdc_msg>-msgv4.
+    elseif msg_type->absolute_name = '\TYPE=HRPAD_MESSAGE'.
+      assign obj_to_log to <hrpad_msg>.
+      detailed_msg-msgty = <hrpad_msg>-msgty.
+      detailed_msg-msgid = <hrpad_msg>-msgid.
+      detailed_msg-msgno = <hrpad_msg>-msgno.
+      detailed_msg-msgv1 = <hrpad_msg>-msgv1.
+      detailed_msg-msgv2 = <hrpad_msg>-msgv2.
+      detailed_msg-msgv3 = <hrpad_msg>-msgv3.
+      detailed_msg-msgv4 = <hrpad_msg>-msgv4.
+    elseif msg_type->absolute_name = '\TYPE=RCOMP'.
+      assign obj_to_log to <rcomp_msg>.
+      detailed_msg-msgty = <rcomp_msg>-msgty.
+      detailed_msg-msgid = <rcomp_msg>-msgid.
+      detailed_msg-msgno = <rcomp_msg>-msgno.
+      detailed_msg-msgv1 = <rcomp_msg>-msgv1.
+      detailed_msg-msgv2 = <rcomp_msg>-msgv2.
+      detailed_msg-msgv3 = <rcomp_msg>-msgv3.
+      detailed_msg-msgv4 = <rcomp_msg>-msgv4.
+    else.
+      free_text_msg = obj_to_log.
+    endif.
+
+    if free_text_msg is not initial.
+      append message_from_string( free_text_msg ) to mt_messages.
+    elseif exception_data_table is not initial.
+      field-symbols <exception_data> like line of exception_data_table.
+      loop at exception_data_table assigning <exception_data>.
+        perform exception_into_msg in program saplsbal
+              using <exception_data>
+              changing detailed_msg.
+        append message_from_bal_s_msg( detailed_msg ) to mt_messages.
+      endloop.
+    elseif detailed_msg is not initial.
+      append message_from_bal_s_msg( detailed_msg ) to mt_messages.
+    endif.
+
+    if auto_save = abap_true.
+      zif_logger~save( ).
+    endif.
+
+    clear m_new_object.
+    self = me.
+  endmethod.
+
+
+  method drill_down_into_exception.
+    data: i                  type i value 2,
+          previous_exception type ref to cx_root,
+          exceptions         type tty_exception.
+
+    field-symbols <ex> like line of exceptions.
+    append initial line to exceptions assigning <ex>.
+    <ex>-level = 1.
+    <ex>-exception = exception.
+
+    previous_exception = exception.
+
+    while i <= max_exception_drill_down.
+      if previous_exception->previous is not bound.
+        exit.
+      endif.
+
+      previous_exception ?= previous_exception->previous.
+
+      append initial line to exceptions assigning <ex>.
+      <ex>-level = i.
+      <ex>-exception = previous_exception.
+      i = i + 1.
+    endwhile.
+
+    field-symbols <ret> like line of rt_exception_data_table.
+    sort exceptions by level descending.                   "Display the deepest exception first
+    loop at exceptions assigning <ex>.
+      append initial line to rt_exception_data_table assigning <ret>.
+      <ret>-exception = <ex>-exception.
+      <ret>-msgty     = type.
+      <ret>-probclass = importance.
+    endloop.
+  endmethod.
+
+
+  method zif_logger~export_to_table.
+    data: log_handle      type bal_t_logh,
+          message_handles type bal_t_msgh,
+          message         type bal_s_msg,
+          bapiret2        type bapiret2.
+
+    field-symbols <msg_handle> type balmsghndl.
+
+    insert handle into table log_handle.
+
+    call function 'BAL_GLB_SEARCH_MSG'
+      exporting
+        i_t_log_handle = log_handle
+      importing
+        e_t_msg_handle = message_handles
+      exceptions
+        msg_not_found  = 0.
+
+    loop at message_handles assigning <msg_handle>.
+      call function 'BAL_LOG_MSG_READ'
+        exporting
+          i_s_msg_handle = <msg_handle>
+        importing
+          e_s_msg        = message
+        exceptions
+          others         = 3.
+      if sy-subrc is initial.
+        message id message-msgid
+                type message-msgty
+                number message-msgno
+                into bapiret2-message
+                with message-msgv1 message-msgv2 message-msgv3 message-msgv4.
+
+        bapiret2-type       = message-msgty.
+        bapiret2-id         = message-msgid.
+        bapiret2-number     = message-msgno.
+        bapiret2-log_no     = <msg_handle>-log_handle.     "last 2 chars missing!!
+        bapiret2-log_msg_no = <msg_handle>-msgnumber.
+        bapiret2-message_v1 = message-msgv1.
+        bapiret2-message_v2 = message-msgv2.
+        bapiret2-message_v3 = message-msgv3.
+        bapiret2-message_v4 = message-msgv4.
+        bapiret2-system     = sy-sysid.
+        append bapiret2 to rt_bapiret.
+      endif.
+    endloop.
+  endmethod.
+
+
+  method zif_logger~fullscreen.
+    call function 'TR_FLUSH_LOG'.
+  endmethod.
+
+
+  method zif_logger~get_autosave.
+    auto_save = me->auto_save.
+  endmethod.
+
+
+  method zif_logger~popup.
+    call function 'TR_FLUSH_LOG'.
+  endmethod.
+
+
+  method zif_logger~save.
+    call function 'TR_APPEND_LOG'
+      tables
+        xmsg           = mt_messages
+      exceptions
+        file_not_found = 1
+        wrong_call     = 2.
+    if sy-subrc = 0.
+      clear mt_messages.
+    endif.
+  endmethod.
+
+
+  method zif_logger~set_autosave.
+    me->auto_save = auto_save.
+  endmethod.
+
+
+  method message_from_string.
+    data:
+      begin of ls_msg,
+        v1 type symsgv,
+        v2 type symsgv,
+        v3 type symsgv,
+        v4 type symsgv,
+      end of ls_msg.
+
+    ls_msg = i_message_text.
+
+    "rs_message-level    =
+    "rs_message-severity =
+    rs_message-langu    = sy-langu.
+    rs_message-ag       = 'BL'.
+    rs_message-msgnr    = '001'.
+    rs_message-newobj   = m_new_object.
+    rs_message-var1     = ls_msg-v1.
+    rs_message-var2     = ls_msg-v2.
+    rs_message-var3     = ls_msg-v3.
+    rs_message-var4     = ls_msg-v4.
+  endmethod.
+
+
+  method message_from_bal_s_msg.
+    "rs_message-level    =
+    "rs_message-severity =
+    rs_message-langu    = sy-langu.
+    rs_message-ag       = is_message-msgid.
+    rs_message-msgnr    = is_message-msgno.
+    rs_message-newobj   = m_new_object.
+    rs_message-var1     = is_message-msgv1.
+    rs_message-var2     = is_message-msgv2.
+    rs_message-var3     = is_message-msgv3.
+    rs_message-var4     = is_message-msgv4.
+  endmethod.
+
+endclass.

--- a/zcl_logger_xpra.clas.locals_def.abap
+++ b/zcl_logger_xpra.clas.locals_def.abap
@@ -1,0 +1,11 @@
+*"* use this source file for any type of declarations (class
+*"* definitions, interfaces or type declarations) you need for
+*"* components in the private section
+
+types: begin of ty_exception,
+         level     type i,
+         exception type ref to cx_root,
+       end of ty_exception,
+       tty_exception type standard table of ty_exception.
+
+types: tty_exception_data    type standard table of bal_s_exc with default key.

--- a/zcl_logger_xpra.clas.testclasses.abap
+++ b/zcl_logger_xpra.clas.testclasses.abap
@@ -1,0 +1,11 @@
+*"* use this source file for your ABAP unit test classes
+
+class lcl_test definition for testing
+  duration short
+  risk level harmless.
+
+  private section.
+    constants c_bal_object type string value 'ABAPUNIT' ##no_text.
+    constants c_bal_subobject type string value 'ZCL_LOGGER' ##no_text.
+
+endclass.

--- a/zcl_logger_xpra.clas.xml
+++ b/zcl_logger_xpra.clas.xml
@@ -4,13 +4,13 @@
   <asx:values>
    <VSEOCLASS>
     <CLSNAME>ZCL_LOGGER_XPRA</CLSNAME>
-    <VERSION>1</VERSION>
     <LANGU>E</LANGU>
     <DESCRIPT>Logger for XPRA reports - add messages to transport log</DESCRIPT>
     <STATE>1</STATE>
     <CLSCCINCL>X</CLSCCINCL>
     <FIXPT>X</FIXPT>
     <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
    <DESCRIPTIONS>
     <SEOCOMPOTX>

--- a/zcl_logger_xpra.clas.xml
+++ b/zcl_logger_xpra.clas.xml
@@ -3,16 +3,23 @@
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>
    <VSEOCLASS>
-    <CLSNAME>ZCL_LOGGER</CLSNAME>
+    <CLSNAME>ZCL_LOGGER_XPRA</CLSNAME>
     <VERSION>1</VERSION>
     <LANGU>E</LANGU>
-    <DESCRIPT>Logger</DESCRIPT>
+    <DESCRIPT>Logger for XPRA reports - add messages to transport log</DESCRIPT>
     <STATE>1</STATE>
     <CLSCCINCL>X</CLSCCINCL>
     <FIXPT>X</FIXPT>
     <UNICODE>X</UNICODE>
-    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
+   <DESCRIPTIONS>
+    <SEOCOMPOTX>
+     <CLSNAME>ZCL_LOGGER_XPRA</CLSNAME>
+     <CMPNAME>MESSAGE_FROM_STRING</CMPNAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>Create message from text string</DESCRIPT>
+    </SEOCOMPOTX>
+   </DESCRIPTIONS>
   </asx:values>
  </asx:abap>
 </abapGit>

--- a/zif_logger.intf.xml
+++ b/zif_logger.intf.xml
@@ -4,7 +4,6 @@
   <asx:values>
    <VSEOINTERF>
     <CLSNAME>ZIF_LOGGER</CLSNAME>
-    <VERSION>1</VERSION>
     <LANGU>E</LANGU>
     <DESCRIPT>Logger Interface</DESCRIPT>
     <EXPOSURE>2</EXPOSURE>

--- a/zif_logger_xpra.intf.abap
+++ b/zif_logger_xpra.intf.abap
@@ -1,0 +1,47 @@
+"#autoformat (Pretty Print class automatically with abapCI plug-in)
+"! <p class="shorttext synchronized" lang="en">Logger interface - transport log</p>
+interface zif_logger_xpra
+  public .
+  interfaces zif_logger.
+
+  constants:
+    "! <p class="shorttext synchronized" lang="en">Level</p>
+    begin of cs_level,
+      "! <p class="shorttext synchronized" lang="en">Statistics level for summary of program results</p>
+      summary  type sprot_u-level value '1' ##no_text,
+      "! <p class="shorttext synchronized" lang="en">Error level for logging results with errors</p>
+      error    type sprot_u-level value '2' ##no_text,
+      "! <p class="shorttext synchronized" lang="en">Overview level for logging all work steps</p>
+      overview type sprot_u-level value '3' ##no_text,
+      "! <p class="shorttext synchronized" lang="en">Detailed level, additional information for the Hotline</p>
+      detail   type sprot_u-level value '4' ##no_text,
+    end of cs_level.
+  constants:
+    "! <p class="shorttext synchronized" lang="en">Severity</p>
+    begin of cs_severity,
+      "! <p class="shorttext synchronized" lang="en">Cancelled (internal error)</p>
+      cancelled   type sprot_u-severity value 'A' ##no_text,
+      "! <p class="shorttext synchronized" lang="en">Fatal error</p>
+      fatal_error type sprot_u-severity value 'F' ##no_text,
+      "! <p class="shorttext synchronized" lang="en">Error (could not execute function)</p>
+      error       type sprot_u-severity value 'E' ##no_text,
+      "! <p class="shorttext synchronized" lang="en">Warning</p>
+      warning     type sprot_u-severity value 'W' ##no_text,
+      "! <p class="shorttext synchronized" lang="en">Information</p>
+      information type sprot_u-severity value 'I' ##no_text,
+      "! <p class="shorttext synchronized" lang="en">tatus message</p>
+      status      type sprot_u-severity value 'S' ##no_text,
+      "! <p class="shorttext synchronized" lang="en">Success (function executed)</p>
+      success     type sprot_u-severity value 'N' ##no_text,
+      "! <p class="shorttext synchronized" lang="en">Open (function not executed yet)</p>
+      open        type sprot_u-severity value ' ' ##no_text,
+    end of cs_severity.
+
+  "! <p class="shorttext synchronized" lang="en">The next message will start a new section</p>
+  "!
+  "! @parameter ro_self | <p class="shorttext synchronized" lang="en"></p>
+  methods start_new_section default ignore
+    returning
+      value(ro_self) type ref to zif_logger_xpra.
+
+endinterface.

--- a/zif_logger_xpra.intf.xml
+++ b/zif_logger_xpra.intf.xml
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_INTF" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOINTERF>
+    <CLSNAME>ZIF_LOGGER_XPRA</CLSNAME>
+    <VERSION>1</VERSION>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Logger interface - transport log</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <UNICODE>X</UNICODE>
+   </VSEOINTERF>
+   <DESCRIPTIONS>
+    <SEOCOMPOTX>
+     <CLSNAME>ZIF_LOGGER_XPRA</CLSNAME>
+     <CMPNAME>CS_LEVEL</CMPNAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>Level</DESCRIPT>
+    </SEOCOMPOTX>
+    <SEOCOMPOTX>
+     <CLSNAME>ZIF_LOGGER_XPRA</CLSNAME>
+     <CMPNAME>CS_LOG_LEVEL</CMPNAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>Log level</DESCRIPT>
+    </SEOCOMPOTX>
+    <SEOCOMPOTX>
+     <CLSNAME>ZIF_LOGGER_XPRA</CLSNAME>
+     <CMPNAME>CS_SEVERITY</CMPNAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>Severity</DESCRIPT>
+    </SEOCOMPOTX>
+    <SEOCOMPOTX>
+     <CLSNAME>ZIF_LOGGER_XPRA</CLSNAME>
+     <CMPNAME>START_NEW_SECTION</CMPNAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>The next message will start a new section</DESCRIPT>
+    </SEOCOMPOTX>
+   </DESCRIPTIONS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/zif_logger_xpra.intf.xml
+++ b/zif_logger_xpra.intf.xml
@@ -4,7 +4,6 @@
   <asx:values>
    <VSEOINTERF>
     <CLSNAME>ZIF_LOGGER_XPRA</CLSNAME>
-    <VERSION>1</VERSION>
     <LANGU>E</LANGU>
     <DESCRIPT>Logger interface - transport log</DESCRIPT>
     <EXPOSURE>2</EXPOSURE>


### PR DESCRIPTION
I have implemented a compatible logger for XPRA report execution which will add messages to the transport log instead of creating an application log in client zero.

As I am still rather new to git I have probably made a few mistakes, and there's a little more included here than what was strictly needed. For instance, I should probably not have staged the package - I see the application component has been committed as a change. Sorry about that. 
One thing that should be included, but should probably have been in a separate pull request is the change from 'LOGGER' to 'ZCL_LOGGER' as application log sub-object for unit tests to avoid problems with name space.

I don't know why the zcl_logger.clas.xml is updated with removal of the class documentation. I have even tried changing the documentation and activating it, but it just won't come back. 

Unit tests.... yes, I should get started on that topic.

If there's too many beginner mistakes to fix, please reject the pull request. In a while I should be able to create one (or several) that can be accepted more smoothly.