### PR TITLE
New expiration feature, refactoring and ABAP Doc

### DIFF
--- a/zcl_logger.clas.testclasses.abap
+++ b/zcl_logger.clas.testclasses.abap
@@ -137,7 +137,7 @@ class lcl_test implementation.
             desc      = 'Log that is deletable and expiring'
             settings  = zcl_logger_factory=>create_settings(
               )->set_expiry_in_days( days_until_log_can_be_deleted
-              )->set_deletable_before_expiry( abap_true )
+              )->set_must_be_kept_until_expiry( abap_false )
           ).
         when 2.     "Expiry with date
           expiring_log = zcl_logger_factory=>create_log(
@@ -146,7 +146,7 @@ class lcl_test implementation.
             desc      = 'Log that is deletable and expiring'
             settings  = zcl_logger_factory=>create_settings(
               )->set_expiry_date( conv #( sy-datum + days_until_log_can_be_deleted )
-              )->set_deletable_before_expiry( abap_true )
+              )->set_must_be_kept_until_expiry( abap_true )
           ).
       endcase.
 

--- a/zcl_logger_factory.clas.abap
+++ b/zcl_logger_factory.clas.abap
@@ -73,7 +73,7 @@ class zcl_logger_factory implementation.
 
 * Set deletion date and set if log can be deleted before deletion date is reached.
     lo_log->header-aldate_del = lo_log->settings->get_expiry_date( ).
-    lo_log->header-del_before = lo_log->settings->get_deletable_before_expiry( ).
+    lo_log->header-del_before = lo_log->settings->get_must_be_kept_until_expiry( ).
 
     if context is supplied and context is not initial.
       lo_log->header-context-tabname =
@@ -179,5 +179,6 @@ class zcl_logger_factory implementation.
     create object r_settings type zcl_logger_settings.
 
   endmethod.
+
 
 endclass.

--- a/zcl_logger_factory.clas.abap
+++ b/zcl_logger_factory.clas.abap
@@ -27,6 +27,12 @@ class zcl_logger_factory definition
       returning
         value(r_log)             type ref to zif_logger .
 
+    "! Creates a settings object which can be modified. It can be pass on
+    "! the creation of the logger to change its behavior.
+    class-methods create_settings
+      returning
+        value(r_settings) type ref to zif_logger_settings.
+
   protected section.
   private section.
 endclass.
@@ -164,6 +170,13 @@ class zcl_logger_factory implementation.
         e_s_log      = lo_log->header.
 
     r_log = lo_log.
+
+  endmethod.
+
+
+  method create_settings.
+
+    create object r_settings type zcl_logger_settings.
 
   endmethod.
 

--- a/zcl_logger_settings.clas.abap
+++ b/zcl_logger_settings.clas.abap
@@ -1,0 +1,84 @@
+class zcl_logger_settings definition
+  public
+  final
+  create private
+  global friends zcl_logger_factory.
+
+  public section.
+    interfaces zif_logger_settings.
+    methods constructor.
+  protected section.
+  private section.
+    data auto_save type abap_bool.
+    data expiry_date type aldate_del .
+    data can_be_deleted_before_expiry type del_before.
+    data max_exception_drill_down type i.
+    data use_2nd_db_connection type flag.
+endclass.
+
+
+
+class zcl_logger_settings implementation.
+
+  method constructor.
+    can_be_deleted_before_expiry = abap_true.
+    max_exception_drill_down = 10.
+    use_2nd_db_connection = abap_true.
+    auto_save = abap_true.
+  endmethod.
+
+  method zif_logger_settings~get_autosave.
+    r_auto_save = auto_save.
+  endmethod.
+
+  method zif_logger_settings~set_autosave.
+    auto_save = i_auto_save.
+    r_self = me.
+  endmethod.
+
+  method zif_logger_settings~get_expiry_date.
+    r_expiry_date = expiry_date.
+  endmethod.
+
+  method zif_logger_settings~set_expiry_date.
+    expiry_date = i_expiry_date.
+    r_self = me.
+  endmethod.
+
+  method zif_logger_settings~set_expiry_in_days.
+    if i_num_days > 0.
+      expiry_date = sy-datum + i_num_days.
+    endif.
+    r_self = me.
+  endmethod.
+
+  method zif_logger_settings~get_deletable_before_expiry.
+    r_can_be_deleted = can_be_deleted_before_expiry.
+  endmethod.
+
+  method zif_logger_settings~set_deletable_before_expiry.
+    can_be_deleted_before_expiry = i_can_be_deleted.
+    r_self = me.
+  endmethod.
+
+  method zif_logger_settings~get_max_exception_drill_down.
+    r_levels = max_exception_drill_down.
+  endmethod.
+
+  method zif_logger_settings~set_max_exception_drill_down.
+    if i_levels >= 0.
+      max_exception_drill_down = i_levels.
+    endif.
+    r_self = me.
+  endmethod.
+
+  method zif_logger_settings~get_usage_of_secondary_db_conn.
+    r_2nd_db_connection_enabled = use_2nd_db_connection.
+  endmethod.
+
+  method zif_logger_settings~set_usage_of_secondary_db_conn.
+    use_2nd_db_connection = i_use_2nd_db_connection.
+    r_self = me.
+  endmethod.
+
+endclass.

--- a/zcl_logger_settings.clas.abap
+++ b/zcl_logger_settings.clas.abap
@@ -11,7 +11,7 @@ class zcl_logger_settings definition
   private section.
     data auto_save type abap_bool.
     data expiry_date type aldate_del .
-    data can_be_deleted_before_expiry type del_before.
+    data must_be_kept_until_expiry type del_before.
     data max_exception_drill_down type i.
     data use_2nd_db_connection type flag.
 endclass.
@@ -21,7 +21,7 @@ endclass.
 class zcl_logger_settings implementation.
 
   method constructor.
-    can_be_deleted_before_expiry = abap_true.
+    must_be_kept_until_expiry = abap_false.
     max_exception_drill_down = 10.
     use_2nd_db_connection = abap_true.
     auto_save = abap_true.
@@ -52,12 +52,12 @@ class zcl_logger_settings implementation.
     r_self = me.
   endmethod.
 
-  method zif_logger_settings~get_deletable_before_expiry.
-    r_can_be_deleted = can_be_deleted_before_expiry.
+  method zif_logger_settings~get_must_be_kept_until_expiry.
+    r_must_be_kept_until_expiry = must_be_kept_until_expiry.
   endmethod.
 
-  method zif_logger_settings~set_deletable_before_expiry.
-    can_be_deleted_before_expiry = i_can_be_deleted.
+  method zif_logger_settings~set_must_be_kept_until_expiry.
+    must_be_kept_until_expiry = i_must_be_kept_until_expiry.
     r_self = me.
   endmethod.
 

--- a/zcl_logger_settings.clas.testclasses.abap
+++ b/zcl_logger_settings.clas.testclasses.abap
@@ -1,0 +1,140 @@
+*"* use this source file for your ABAP unit test classes
+class lcl_logger_settings_should definition deferred.
+class zcl_logger_settings definition local friends lcl_logger_settings_should.
+
+class lcl_logger_settings_should definition for testing
+  risk level harmless
+  duration short.
+
+  private section.
+    data cut type ref to zcl_logger_settings.
+    methods setup.
+    methods have_correct_defaults for testing.
+    methods set_autosave for testing.
+    methods set_expiry_date for testing.
+    methods set_expiry_in_days for testing.
+    methods set_flag_to_keep_until_expiry for testing.
+    methods set_usage_of_2nd_db_connection for testing.
+    methods set_max_drilldown_level for testing.
+endclass.
+
+class lcl_logger_settings_should implementation.
+
+  method setup.
+    cut = new #( ).
+  endmethod.
+
+  method have_correct_defaults.
+    cl_aunit_assert=>assert_equals(
+      exporting
+        exp     = abap_true
+        act     = cut->zif_logger_settings~get_autosave( )
+        msg     = |Auto save should be on by default|
+    ).
+    cl_aunit_assert=>assert_equals(
+      exporting
+        exp     = abap_true
+        act     = cut->zif_logger_settings~get_usage_of_secondary_db_conn( )
+        msg     = |2nd database connection should be used by default|
+    ).
+    cl_aunit_assert=>assert_equals(
+      exporting
+        exp     = abap_false
+        act     = cut->zif_logger_settings~get_must_be_kept_until_expiry( )
+        msg     = |Log should be deletable before expiry date is reached by default|
+    ).
+    cl_aunit_assert=>assert_initial(
+      exporting
+        act     = cut->zif_logger_settings~get_expiry_date( )
+        msg     = |No expiry date set by default|
+    ).
+    cl_aunit_assert=>assert_equals(
+      exporting
+        exp     = 10
+        act     = cut->zif_logger_settings~get_max_exception_drill_down( )
+        msg     = |Max exception drill down should be 10 by default|
+    ).
+  endmethod.
+
+  method set_autosave.
+    cut->zif_logger_settings~set_autosave( abap_false ).
+    cl_aunit_assert=>assert_equals(
+      exporting
+        exp     = abap_false
+        act     = cut->zif_logger_settings~get_autosave( )
+        msg     = |Auto save was not deactivated correctly|
+    ).
+  endmethod.
+
+  method set_expiry_date.
+    cut->zif_logger_settings~set_expiry_date( '20161030' ).
+    cl_aunit_assert=>assert_equals(
+      exporting
+        exp     = '20161030'
+        act     = cut->zif_logger_settings~get_expiry_date( )
+        msg     = |Expiry date was not set correctly|
+    ).
+  endmethod.
+
+  method set_expiry_in_days.
+    cut->zif_logger_settings~set_expiry_in_days( -1 ).
+    cl_aunit_assert=>assert_initial(
+      exporting
+        act     = cut->zif_logger_settings~get_expiry_date( )
+        msg     = |Expiry in days should remain default when setting incorrect values.|
+    ).
+
+    cut->zif_logger_settings~set_expiry_in_days( 10 ).
+    cl_aunit_assert=>assert_equals(
+      exporting
+        exp     = conv d( sy-datum + 10 )
+        act     = cut->zif_logger_settings~get_expiry_date( )
+        msg     = |Expiry in days was not set correctly.|
+    ).
+  endmethod.
+
+  method set_flag_to_keep_until_expiry.
+    cut->zif_logger_settings~set_must_be_kept_until_expiry( abap_true ).
+    cl_aunit_assert=>assert_equals(
+      exporting
+        exp     = abap_true
+        act     = cut->zif_logger_settings~get_must_be_kept_until_expiry( )
+        msg     = |Setter for keeping log until expiry is not working correctly.|
+    ).
+  endmethod.
+
+  method set_usage_of_2nd_db_connection.
+    cut->zif_logger_settings~set_usage_of_secondary_db_conn( abap_false ).
+    cl_aunit_assert=>assert_equals(
+      exporting
+        exp     = abap_false
+        act     = cut->zif_logger_settings~get_usage_of_secondary_db_conn( )
+        msg     = |Setter for using 2nd db connection is not working correctly.|
+    ).
+  endmethod.
+
+  method set_max_drilldown_level.
+    cut->zif_logger_settings~set_max_exception_drill_down( 20 ).
+    cl_aunit_assert=>assert_equals(
+      exporting
+        exp     = 20
+        act     = cut->zif_logger_settings~get_max_exception_drill_down( )
+        msg     = |Setter for max drilldown level is not working correctly.|
+    ).
+    cut->zif_logger_settings~set_max_exception_drill_down( -1 ).
+    cl_aunit_assert=>assert_equals(
+      exporting
+        exp     = 20
+        act     = cut->zif_logger_settings~get_max_exception_drill_down( )
+        msg     = |Max exception drill down level should not change if value is incorrect.|
+    ).
+    cut->zif_logger_settings~set_max_exception_drill_down( 0 ).
+    cl_aunit_assert=>assert_equals(
+      exporting
+        exp     = 0
+        act     = cut->zif_logger_settings~get_max_exception_drill_down( )
+        msg     = |Max exception drill down should be deactivatable.|
+    ).
+  endmethod.
+
+endclass.

--- a/zcl_logger_settings.clas.xml
+++ b/zcl_logger_settings.clas.xml
@@ -11,6 +11,7 @@
     <CLSCCINCL>X</CLSCCINCL>
     <FIXPT>X</FIXPT>
     <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
   </asx:values>
  </asx:abap>

--- a/zcl_logger_settings.clas.xml
+++ b/zcl_logger_settings.clas.xml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_LOGGER_SETTINGS</CLSNAME>
+    <VERSION>1</VERSION>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Logger settings</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/zif_logger.intf.abap
+++ b/zif_logger.intf.abap
@@ -3,6 +3,7 @@ interface zif_logger
   data handle type balloghndl read-only .
   data db_number type balognr read-only .
   data header type bal_s_log read-only .
+
   methods add
     importing
       obj_to_log    type any optional
@@ -15,6 +16,7 @@ interface zif_logger
         preferred parameter obj_to_log
     returning
       value(self)   type ref to zif_logger .
+
   methods a
     importing
       obj_to_log    type any optional
@@ -26,6 +28,7 @@ interface zif_logger
         preferred parameter obj_to_log
     returning
       value(self)   type ref to zif_logger .
+
   methods e
     importing
       obj_to_log    type any optional
@@ -37,6 +40,7 @@ interface zif_logger
         preferred parameter obj_to_log
     returning
       value(self)   type ref to zif_logger .
+
   methods w
     importing
       obj_to_log    type any optional
@@ -48,6 +52,7 @@ interface zif_logger
         preferred parameter obj_to_log
     returning
       value(self)   type ref to zif_logger .
+
   methods i
     importing
       obj_to_log    type any optional
@@ -59,6 +64,7 @@ interface zif_logger
         preferred parameter obj_to_log
     returning
       value(self)   type ref to zif_logger .
+
   methods s
     importing
       obj_to_log    type any optional
@@ -70,17 +76,21 @@ interface zif_logger
         preferred parameter obj_to_log
     returning
       value(self)   type ref to zif_logger .
+
+  "! Saves the log on demand. Intended to be called at the
+  "! end of the log processing so that logs can be saved depending
+  "! on other criteria, like the existence of error messages.
+  "! If there are no error messages, it may not be desirable to save
+  "! a log.
+  "! If auto save is enabled, save will do nothing.
   methods save .
-  methods get_autosave
-    returning
-      value(auto_save) type abap_bool .
-  methods set_autosave
-    importing
-      auto_save type abap_bool .
+
   methods export_to_table
     returning
       value(rt_bapiret) type bapirettab .
+
   methods fullscreen .
+
   methods popup .
 
 endinterface.

--- a/zif_logger_settings.intf.abap
+++ b/zif_logger_settings.intf.abap
@@ -1,19 +1,12 @@
 interface zif_logger_settings public .
 
   "! Is the log automatically saved when adding messages?
-  "!
-  "! If auto save is disabled, the save() method has to be called manually
-  "! to write the data to the database (it commits the LUW).
-  "! If auto save is enabled, the save() method has no effect.
-  "! By default, auto save is enabled.
-  "!
-  "! Be careful with enabled auto save when processing mass data because it
-  "! can decrease system performance significantly.
+  "! See setter for more details.
   methods get_autosave
     returning
       value(r_auto_save) type abap_bool.
 
-  "! Sets if the log is automatically saved when adding messages.
+  "! Set to true if the log is automatically saved when adding messages.
   "!
   "! If auto save is disabled, the save() method has to be called manually
   "! to write the data to the database (it commits the LUW).
@@ -29,9 +22,7 @@ interface zif_logger_settings public .
       value(r_self) type ref to zif_logger_settings.
 
   "! Get the earliest date on which the log can be deleted.
-  "! By default the log does not expire.
-  "!
-  "! Further information: https://launchpad.support.sap.com/#/notes/195157
+  "! See setter for more details.
   methods get_expiry_date
     returning
       value(r_expiry_date) type aldate_del.
@@ -56,23 +47,22 @@ interface zif_logger_settings public .
     returning
       value(r_self) type ref to zif_logger_settings.
 
-  "! Can the log be deleted before the expiry date is reached?
-  "! The default is true.
-  "!
-  "! Further information: https://launchpad.support.sap.com/#/notes/195157
-  methods get_deletable_before_expiry
+  "! Does the log have to be kept until the expiry date is reached?
+  "! See setter for more details.
+  methods get_must_be_kept_until_expiry
     returning
-      value(r_can_be_deleted) type del_before.
+      value(r_must_be_kept_until_expiry) type del_before.
 
-  "! Set if log should be deletable before expiry date is reached.
-  "! The default is true.
+  "! Set to true if log must be kept until the expiry date is reached. It
+  "! cannot be deleted before (in transaction SLG2).
+  "! The default is false.
   "!
   "! Further information: https://launchpad.support.sap.com/#/notes/195157
-  methods set_deletable_before_expiry
+  methods set_must_be_kept_until_expiry
     importing
-      i_can_be_deleted type del_before
+      i_must_be_kept_until_expiry type del_before
     returning
-      value(r_self)    type ref to zif_logger_settings.
+      value(r_self)               type ref to zif_logger_settings.
 
   methods get_max_exception_drill_down
     returning
@@ -85,7 +75,7 @@ interface zif_logger_settings public .
       value(r_self) type ref to zif_logger_settings.
 
   "! Is a secondary database connection used to write the log entries to the database?
-  "! This is important if main program does a rollback (on purpose or after a dump).
+  "! See setter for more details.
   methods get_usage_of_secondary_db_conn
     returning
       value(r_2nd_db_connection_enabled) type flag.

--- a/zif_logger_settings.intf.abap
+++ b/zif_logger_settings.intf.abap
@@ -1,0 +1,102 @@
+interface zif_logger_settings public .
+
+  "! Is the log automatically saved when adding messages?
+  "!
+  "! If auto save is disabled, the save() method has to be called manually
+  "! to write the data to the database (it commits the LUW).
+  "! If auto save is enabled, the save() method has no effect.
+  "! By default, auto save is enabled.
+  "!
+  "! Be careful with enabled auto save when processing mass data because it
+  "! can decrease system performance significantly.
+  methods get_autosave
+    returning
+      value(r_auto_save) type abap_bool.
+
+  "! Sets if the log is automatically saved when adding messages.
+  "!
+  "! If auto save is disabled, the save() method has to be called manually
+  "! to write the data to the database (it commits the LUW).
+  "! If auto save is enabled, the save() method has no effect.
+  "! By default, auto save is enabled.
+  "!
+  "! Be careful with enabled auto save when processing mass data because it
+  "! can decrease system performance significantly.
+  methods set_autosave
+    importing
+      i_auto_save   type abap_bool
+    returning
+      value(r_self) type ref to zif_logger_settings.
+
+  "! Get the earliest date on which the log can be deleted.
+  "! By default the log does not expire.
+  "!
+  "! Further information: https://launchpad.support.sap.com/#/notes/195157
+  methods get_expiry_date
+    returning
+      value(r_expiry_date) type aldate_del.
+
+  "! Set the earliest date on which the log can be deleted.
+  "! By default the log does not expire.
+  "!
+  "! Further information: https://launchpad.support.sap.com/#/notes/195157
+  methods set_expiry_date
+    importing
+      i_expiry_date type aldate_del
+    returning
+      value(r_self) type ref to zif_logger_settings.
+
+  "! Set the number of days after which the log can be deleted.
+  "! By default the log does not expire.
+  "!
+  "! Further information: https://launchpad.support.sap.com/#/notes/195157
+  methods set_expiry_in_days
+    importing
+      i_num_days    type i
+    returning
+      value(r_self) type ref to zif_logger_settings.
+
+  "! Can the log be deleted before the expiry date is reached?
+  "! The default is true.
+  "!
+  "! Further information: https://launchpad.support.sap.com/#/notes/195157
+  methods get_deletable_before_expiry
+    returning
+      value(r_can_be_deleted) type del_before.
+
+  "! Set if log should be deletable before expiry date is reached.
+  "! The default is true.
+  "!
+  "! Further information: https://launchpad.support.sap.com/#/notes/195157
+  methods set_deletable_before_expiry
+    importing
+      i_can_be_deleted type del_before
+    returning
+      value(r_self)    type ref to zif_logger_settings.
+
+  methods get_max_exception_drill_down
+    returning
+      value(r_levels) type i.
+
+  methods set_max_exception_drill_down
+    importing
+      i_levels      type i
+    returning
+      value(r_self) type ref to zif_logger_settings.
+
+  "! Is a secondary database connection used to write the log entries to the database?
+  "! This is important if main program does a rollback (on purpose or after a dump).
+  methods get_usage_of_secondary_db_conn
+    returning
+      value(r_2nd_db_connection_enabled) type flag.
+
+  "! Set to true if secondary database connection should be used to write the log entries to the database.
+  "! This is important if main program does a rollback (on purpose or after a dump).
+  "! The default is true.
+  methods set_usage_of_secondary_db_conn
+    importing
+      i_use_2nd_db_connection type flag
+    returning
+      value(r_self)           type ref to zif_logger_settings.
+
+endinterface.

--- a/zif_logger_settings.intf.xml
+++ b/zif_logger_settings.intf.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_INTF" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOINTERF>
+    <CLSNAME>ZIF_LOGGER_SETTINGS</CLSNAME>
+    <VERSION>1</VERSION>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Interface for logger settings</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <UNICODE>X</UNICODE>
+   </VSEOINTERF>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
- New feature: Expiration of logs so logs can be deleted easier with transaction SLG2. In SAP standard there are two parameters, ALDATE_DEL and DEL_BEFORE, which can be set when creating a log to govern expiration. For further details read https://launchpad.support.sap.com/#/notes/195157
- Introducing a separate Settings class that handles the optional parameters used to create the logger which have grown in the past. Settings class also handles default values and checks input values. Backwards compatibility of the old new() and open() constructor methods have remained. Factory methods have changed and must also be changed in calling code.
- Added new ABAP Doc or converted existing comments to ABAP Doc. There is still room for improvement. ABAP Doc is available in Eclipse when pressing F2 on a method call so it is quite helpful as it is integrated into the IDE.