### PR TITLE
Null device logger implementation

### DIFF
--- a/zcl_logger_factory.clas.abap
+++ b/zcl_logger_factory.clas.abap
@@ -36,9 +36,6 @@ class zcl_logger_factory definition
 
   protected section.
   private section.
-    methods create_null_device_logger
-      returning 
-        value(result) type ref to zif_logger.
 ENDCLASS.
 
 
@@ -51,7 +48,7 @@ CLASS ZCL_LOGGER_FACTORY IMPLEMENTATION.
     field-symbols <context_val> type c.
     
     if log_to_null_device = abap_true.
-      r_log = create_null_device_logger( ).
+      create object r_log type zcl_logger_null_device.
       return.
     endif.
 
@@ -186,10 +183,5 @@ CLASS ZCL_LOGGER_FACTORY IMPLEMENTATION.
 
     r_log = lo_log.
 
-  endmethod.
-  
-  
-  method create_null_device_logger.
-    result = new zcl_logger_null_device( ).
   endmethod.
 ENDCLASS.

--- a/zcl_logger_factory.clas.abap
+++ b/zcl_logger_factory.clas.abap
@@ -8,11 +8,12 @@ class zcl_logger_factory definition
     "! Starts a new log.
     class-methods create_log
       importing
-        object       type csequence optional
-        subobject    type csequence optional
-        desc         type csequence optional
-        context      type simple optional
-        settings     type ref to zif_logger_settings optional
+        !object             type csequence optional
+        !subobject          type csequence optional
+        !desc               type csequence optional
+        !context            type simple optional
+        !settings           type ref to zif_logger_settings optional
+        !log_to_null_device type abap_bool default abap_false
       returning
         value(r_log) type ref to zif_logger .
 
@@ -35,6 +36,9 @@ class zcl_logger_factory definition
 
   protected section.
   private section.
+    methods create_null_device_logger
+      returning 
+        value(result) type ref to zif_logger.
 ENDCLASS.
 
 
@@ -43,9 +47,13 @@ CLASS ZCL_LOGGER_FACTORY IMPLEMENTATION.
 
 
   method create_log.
-
     data: lo_log type ref to zcl_logger.
     field-symbols <context_val> type c.
+    
+    if log_to_null_device = abap_true.
+      r_log = create_null_device_logger( ).
+      return.
+    endif.
 
     create object lo_log.
     lo_log->header-object    = object.
@@ -178,5 +186,10 @@ CLASS ZCL_LOGGER_FACTORY IMPLEMENTATION.
 
     r_log = lo_log.
 
+  endmethod.
+  
+  
+  method create_null_device_logger.
+    result = new zcl_logger_null_device( ).
   endmethod.
 ENDCLASS.

--- a/zcl_logger_null_device.clas.abap
+++ b/zcl_logger_null_device.clas.abap
@@ -1,0 +1,90 @@
+"! <p class="shorttext synchronized" lang="en">Dummy logger which discards all input</p>
+class zcl_logger_null_device definition 
+  public
+  final
+  create private
+  global friends zcl_logger_factory.
+
+  public section.
+    interfaces zif_logger.
+
+    methods constructor.
+
+  protected section.
+  private section.
+endclass.
+
+
+class zcl_logger_null_device implementation.
+  method constructor.
+    zif_logger~handle = '/dev/null'.
+    zif_logger~db_number = '/dev/null'.
+    zif_logger~header-extnumber = '/dev/null'.
+  endmethod.
+
+
+  method zif_logger~a.
+    self = me.
+  endmethod.
+
+
+  method zif_logger~add ##needed.
+    self = me.
+  endmethod.
+
+
+  method zif_logger~e ##needed.
+    self = me.
+  endmethod.
+
+
+  method zif_logger~export_to_table ##needed.
+  endmethod.
+
+
+  method zif_logger~fullscreen ##needed.
+  endmethod.
+
+
+  method zif_logger~has_errors  ##needed.
+    rv_yes = abap_false.
+  endmethod.
+
+
+  method zif_logger~has_warnings ##needed.
+    rv_yes = abap_false.
+  endmethod.
+
+
+  method zif_logger~i ##needed.
+    self = me.
+  endmethod.
+
+
+  method zif_logger~is_empty ##needed.
+    rv_yes = abap_true.
+  endmethod.
+
+
+  method zif_logger~length ##needed.
+    rv_length = 0.
+  endmethod.
+
+
+  method zif_logger~popup ##needed.
+  endmethod.
+
+
+  method zif_logger~s ##needed.
+    self = me.
+  endmethod.
+
+
+  method zif_logger~save ##needed.
+  endmethod.
+
+
+  method zif_logger~w ##needed.
+    self = me.
+  endmethod.
+endclass.

--- a/zcl_logger_null_device.clas.xml
+++ b/zcl_logger_null_device.clas.xml
@@ -1,0 +1,15 @@
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_LOGGER_NULL_DEVICE</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Dummy logger which discards all input</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
Tired of checking IF logger IS BOUND AND IS NOT INITIAL before logging?
Check it once, in the constructor or factory method.
Create a null device logger if a logger is not supplied and worry no more.

It's simple: zcl_logger_factory=>create_log( log_to_null_device = abap_true ).